### PR TITLE
Add standalone 3D logo viewer and link from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -383,6 +383,21 @@
       text-align: center;
       max-width: 360px;
     }
+    .hero-logo-card--interactive {
+      text-decoration: none;
+      color: inherit;
+      transition: transform 0.35s ease, box-shadow 0.35s ease;
+      cursor: pointer;
+    }
+    .hero-logo-card--interactive:hover,
+    .hero-logo-card--interactive:focus-visible {
+      transform: translateY(-6px);
+      box-shadow: 0 30px 60px rgba(0,0,0,0.45);
+    }
+    .hero-logo-card--interactive:focus-visible {
+      outline: 2px solid rgba(0,255,200,0.65);
+      outline-offset: 4px;
+    }
     .hero-logo-card img {
       width: clamp(220px, 62vw, 300px);
       height: auto;
@@ -825,7 +840,9 @@
 </head>
 <body id="top">
   <header>
-    <a href="#top"><img src="3DVR.png" alt="3dvr.tech logo" /></a>
+    <a href="logo-3d.html" target="_blank" rel="noopener" aria-label="Open the 3dvr.tech logo in an interactive 3D viewer">
+      <img src="3DVR.png" alt="3dvr.tech logo" />
+    </a>
 
     <!-- a11y & control bindings for mobile menu -->
     <div
@@ -861,15 +878,21 @@
       <div class="hero-intro">
         <p class="hero-eyebrow">People-first web & XR studio</p>
       </div>
-      <div class="hero-visual" aria-hidden="true">
-        <div class="hero-logo-card">
+      <div class="hero-visual">
+        <a
+          class="hero-logo-card hero-logo-card--interactive"
+          href="logo-3d.html"
+          target="_blank"
+          rel="noopener"
+          aria-label="Open an interactive 3D version of the 3dvr.tech logo"
+        >
           <div class="hero-spark hero-spark--top"></div>
           <div class="hero-spark hero-spark--bottom"></div>
           <img src="3DVR.png" alt="" />
           <p>
             Open source. Community powered. Focused on experiences that feel as visionary as they are sustainable.
           </p>
-        </div>
+        </a>
       </div>
       <div class="hero-content">
         <h1 class="hero-headline">

--- a/logo-3d.html
+++ b/logo-3d.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="color-scheme" content="dark light" />
+  <title>3dvr.tech | 3D Logo Playground</title>
+  <link rel="icon" href="3DVRfavicon.png" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Poppins:wght@600&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --accent: #00ffc8;
+      --bg: radial-gradient(circle at top, rgba(0, 255, 200, 0.25), transparent 55%),
+        radial-gradient(circle at bottom right, rgba(255, 165, 92, 0.2), transparent 60%),
+        linear-gradient(160deg, #232526 0%, #414345 100%);
+      --panel: rgba(0, 0, 0, 0.45);
+      --text: #f9fbff;
+    }
+
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: 'Inter', sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: clamp(1.5rem, 3vw, 2.5rem);
+      padding: clamp(1.5rem, 4vw, 3rem);
+    }
+
+    header {
+      text-align: center;
+      max-width: 720px;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      padding: clamp(1rem, 2vw, 1.5rem);
+      background: var(--panel);
+      border-radius: 20px;
+      box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
+      backdrop-filter: blur(12px);
+    }
+
+    h1 {
+      font-family: 'Poppins', sans-serif;
+      font-size: clamp(1.75rem, 4vw, 2.4rem);
+      letter-spacing: 0.04em;
+    }
+
+    p {
+      line-height: 1.65;
+      font-size: clamp(1rem, 2.5vw, 1.15rem);
+      color: rgba(249, 251, 255, 0.85);
+    }
+
+    .viewer {
+      width: min(960px, 95vw);
+      aspect-ratio: 16 / 9;
+      border-radius: 24px;
+      overflow: hidden;
+      position: relative;
+      box-shadow: 0 30px 55px rgba(0, 0, 0, 0.4);
+      background: rgba(9, 16, 22, 0.75);
+      backdrop-filter: blur(10px);
+    }
+
+    canvas {
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
+
+    .controls {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+      justify-content: center;
+      align-items: center;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.65rem 1.15rem;
+      border-radius: 999px;
+      background: rgba(0, 255, 200, 0.16);
+      border: 1px solid rgba(0, 255, 200, 0.4);
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 600;
+      transition: transform 0.25s ease, background 0.25s ease;
+    }
+
+    .btn:hover {
+      transform: translateY(-2px);
+      background: rgba(0, 255, 200, 0.28);
+    }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      border: 0;
+    }
+
+    @media (max-width: 600px) {
+      header {
+        text-align: left;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Explore the 3dvr.tech Logo in 3D</h1>
+    <p>
+      Orbit, zoom, and pan around the refreshed 3dvr.tech logomark. This interactive viewer uses our production-ready FBX file so you can experience how the identity comes alive in three dimensions.
+    </p>
+  </header>
+
+  <div class="viewer" id="viewer" aria-live="polite">
+    <span class="sr-only" id="loading-status">Loading 3D logo&hellip;</span>
+  </div>
+
+  <div class="controls">
+    <a class="btn" href="index.html">&larr; Back to 3dvr.tech</a>
+    <a class="btn" href="media/3dvr-3d-logo.fbx" download>Download FBX</a>
+  </div>
+
+  <script type="module">
+    import * as THREE from 'https://unpkg.com/three@0.156.1/build/three.module.js';
+    import { OrbitControls } from 'https://unpkg.com/three@0.156.1/examples/jsm/controls/OrbitControls.js';
+    import { FBXLoader } from 'https://unpkg.com/three@0.156.1/examples/jsm/loaders/FBXLoader.js';
+
+    const container = document.getElementById('viewer');
+    const statusEl = document.getElementById('loading-status');
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x0b1117);
+
+    const camera = new THREE.PerspectiveCamera(45, container.clientWidth / container.clientHeight, 0.1, 1000);
+    camera.position.set(2.5, 2.2, 4.5);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setPixelRatio(window.devicePixelRatio);
+    renderer.setSize(container.clientWidth, container.clientHeight);
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    container.appendChild(renderer.domElement);
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableDamping = true;
+    controls.dampingFactor = 0.08;
+    controls.enablePan = true;
+    controls.target.set(0, 1, 0);
+
+    const ambientLight = new THREE.AmbientLight(0xffffff, 0.6);
+    scene.add(ambientLight);
+
+    const keyLight = new THREE.DirectionalLight(0x00ffc8, 1.1);
+    keyLight.position.set(5, 10, 7);
+    scene.add(keyLight);
+
+    const fillLight = new THREE.DirectionalLight(0xff6e7f, 0.6);
+    fillLight.position.set(-4, 6, -5);
+    scene.add(fillLight);
+
+    const loader = new FBXLoader();
+    loader.load(
+      'media/3dvr-3d-logo.fbx',
+      (object) => {
+        object.traverse((child) => {
+          if (child.isMesh) {
+            child.castShadow = true;
+            child.receiveShadow = true;
+          }
+        });
+
+        object.scale.setScalar(0.005);
+        object.position.set(0, 0, 0);
+
+        const box = new THREE.Box3().setFromObject(object);
+        const center = box.getCenter(new THREE.Vector3());
+        object.position.sub(center);
+        object.position.y = -box.min.y * 0.5;
+
+        scene.add(object);
+        statusEl.textContent = '3D logo loaded. Use your mouse or touch to interact.';
+      },
+      (xhr) => {
+        const percent = xhr.total ? ((xhr.loaded / xhr.total) * 100).toFixed(0) : '...';
+        statusEl.textContent = `Loading 3D logo… ${percent}%`;
+      },
+      (error) => {
+        console.error('Error loading FBX:', error);
+        statusEl.textContent = 'We could not load the 3D logo. Please try again later or download the FBX directly.';
+      }
+    );
+
+    const handleResize = () => {
+      const { clientWidth, clientHeight } = container;
+      camera.aspect = clientWidth / clientHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(clientWidth, clientHeight);
+    };
+
+    window.addEventListener('resize', handleResize);
+    handleResize();
+
+    const animate = () => {
+      requestAnimationFrame(animate);
+      controls.update();
+      renderer.render(scene, camera);
+    };
+
+    animate();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated 3D logo playground page that loads the FBX asset with three.js
- wire the site logo and hero badge to open the interactive experience in a new tab and add hover/focus treatments

## Testing
- Manual QA: python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68efe33d8f4c8320b306452fefa36559