### PR TITLE
Center odd homepage plan chip rows

### DIFF
--- a/index.html
+++ b/index.html
@@ -616,7 +616,14 @@
       .hero-intro { text-align: center; margin-bottom: 0; align-self: center; }
       .hero-content { text-align: center; align-items: center; margin-top: 0; }
       .hero p { max-width: none; }
-      .hero-plan-dock__grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .hero-plan-dock__grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+      .hero-plan-dock__grid > :last-child:nth-child(odd) {
+        grid-column: 1 / -1;
+        justify-self: center;
+        width: min(100%, calc(50% - 0.4rem));
+      }
       .hero-buyer-dock__grid { grid-template-columns: 1fr; }
       .hero-vision-highlights { text-align: left; }
       .hero-logo-card {

--- a/tests/playwright/homepage-mobile.spec.js
+++ b/tests/playwright/homepage-mobile.spec.js
@@ -31,4 +31,35 @@ test.describe('homepage mobile sticky CTA', () => {
 
     await expect(stickyCta).toBeVisible();
   });
+
+  test('centers the final hero plan chip when the mobile plan row count is odd', async ({ page }, testInfo) => {
+    test.skip(!isMobileProject(testInfo), 'Mobile-only homepage check');
+
+    await page.goto('/');
+
+    const layout = await page.evaluate(() => {
+      const grid = document.querySelector('.hero-plan-dock__grid');
+      const chips = Array.from(document.querySelectorAll('.hero-plan-chip'));
+
+      if (!grid || chips.length === 0) {
+        return null;
+      }
+
+      const gridRect = grid.getBoundingClientRect();
+      const lastRect = chips.at(-1).getBoundingClientRect();
+
+      return {
+        chipCount: chips.length,
+        gridCenter: Math.round(gridRect.left + (gridRect.width / 2)),
+        lastCenter: Math.round(lastRect.left + (lastRect.width / 2)),
+        lastWidth: Math.round(lastRect.width),
+        gridWidth: Math.round(gridRect.width),
+      };
+    });
+
+    expect(layout).not.toBeNull();
+    expect(layout.chipCount % 2).toBe(1);
+    expect(layout.lastWidth).toBeLessThan(layout.gridWidth);
+    expect(Math.abs(layout.lastCenter - layout.gridCenter)).toBeLessThanOrEqual(2);
+  });
 });


### PR DESCRIPTION
## Goal
Center the last homepage plan chip on mobile when the number of plan chips is odd.

## What changed
- centered the last hero plan chip across the mobile two-column grid when the count is odd
- added a Playwright check that the last mobile hero plan chip stays centered

## Verification
- npx playwright test tests/playwright/homepage-mobile.spec.js --project=chromium-fold-closed --project=webkit-mobile-safari --reporter=line
- git diff --check