### PR TITLE
Clarify lead-to-customer pipeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -1122,6 +1122,105 @@
       background: rgba(0,255,200,0.22);
     }
 
+    .pipeline-section {
+      position: relative;
+      overflow: hidden;
+      isolation: isolate;
+      background:
+        radial-gradient(circle at 12% 18%, rgba(0, 255, 200, 0.16) 0%, rgba(0, 255, 200, 0) 40%),
+        radial-gradient(circle at 86% 78%, rgba(255, 165, 92, 0.22) 0%, rgba(255, 165, 92, 0) 42%),
+        linear-gradient(140deg, #112235 0%, #16334a 52%, #101b2f 100%);
+    }
+    .pipeline-shell {
+      position: relative;
+      z-index: 1;
+      width: min(100%, 1100px);
+      display: grid;
+      gap: 2rem;
+    }
+    .pipeline-heading {
+      display: grid;
+      gap: 0.9rem;
+      justify-items: center;
+    }
+    .pipeline-heading p {
+      max-width: 820px;
+      color: rgba(255, 255, 255, 0.84);
+    }
+    .pipeline-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1.25rem;
+      width: 100%;
+    }
+    .pipeline-card {
+      display: grid;
+      gap: 0.8rem;
+      padding: 1.5rem;
+      border-radius: 22px;
+      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      box-shadow: 0 18px 36px rgba(5, 18, 32, 0.32);
+      text-align: left;
+    }
+    .pipeline-step {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: fit-content;
+      padding: 0.4rem 0.75rem;
+      border-radius: 999px;
+      background: rgba(0, 255, 200, 0.14);
+      border: 1px solid rgba(0, 255, 200, 0.24);
+      color: var(--accent);
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .pipeline-card h3 {
+      color: #ffffff;
+      margin: 0;
+      font-size: 1.35rem;
+    }
+    .pipeline-card p {
+      margin: 0;
+      font-size: 1rem;
+      color: rgba(255, 255, 255, 0.8);
+      line-height: 1.65;
+      max-width: none;
+    }
+    .pipeline-actions {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 1rem;
+    }
+    .pipeline-link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.45rem;
+      padding: 0.85rem 1.35rem;
+      border-radius: 999px;
+      font-weight: 700;
+      text-decoration: none;
+      transition: transform 0.25s ease, background 0.25s ease, border-color 0.25s ease;
+    }
+    .pipeline-link:hover {
+      transform: translateY(-2px);
+    }
+    .pipeline-link--primary {
+      background: var(--accent);
+      color: var(--text-dark);
+      box-shadow: 0 12px 28px rgba(0, 255, 200, 0.28);
+    }
+    .pipeline-link--secondary {
+      background: rgba(255, 255, 255, 0.06);
+      color: #fff;
+      border: 1px solid rgba(255, 255, 255, 0.16);
+    }
+
     @keyframes fadeSlideIn { to { opacity: 1; transform: translateY(0); } }
     @keyframes fadeIn { to { opacity: 1; } }
   </style>
@@ -1149,6 +1248,7 @@
     <nav id="mainNav">
       <a href="subscribe/index.html">Start Free</a>
       <a href="#vision">What We Do</a>
+      <a href="#pipeline">How it works</a>
       <a href="#subscribe">Plans</a>
       <a href="#testimonials">Trust</a>
       <a href="https://portal.3dvr.tech">Portal</a>
@@ -1286,6 +1386,43 @@
           See plans and services
           <i class="fa-solid fa-arrow-up-right-from-square" aria-hidden="true"></i>
         </a>
+      </div>
+    </div>
+  </section>
+
+  <section id="pipeline" class="pipeline-section">
+    <div class="pipeline-shell">
+      <div class="pipeline-heading">
+        <h2>From lead generation to customer journey</h2>
+        <p>
+          The public site should help the right buyer self-identify, raise a hand, continue in portal billing, and move into onboarding without losing the thread.
+        </p>
+      </div>
+      <div class="pipeline-grid">
+        <article class="pipeline-card">
+          <span class="pipeline-step">Step 1</span>
+          <h3>Find the fit</h3>
+          <p>Use the homepage, business-type pages, and plan ladder to point the buyer toward the clearest lane before the conversation gets muddy.</p>
+        </article>
+        <article class="pipeline-card">
+          <span class="pipeline-step">Step 2</span>
+          <h3>Raise your hand</h3>
+          <p>Start free, pick a paid plan, or talk through custom scope so the lead becomes a real contact with a real next step.</p>
+        </article>
+        <article class="pipeline-card">
+          <span class="pipeline-step">Step 3</span>
+          <h3>Continue in portal</h3>
+          <p>Portal billing keeps free access, upgrades, invoices, and support on the same account instead of splitting the customer journey.</p>
+        </article>
+        <article class="pipeline-card">
+          <span class="pipeline-step">Step 4</span>
+          <h3>Onboard and deliver</h3>
+          <p>After checkout, the portal start flow and project lane make the next move obvious for both Thomas and the customer.</p>
+        </article>
+      </div>
+      <div class="pipeline-actions">
+        <a class="pipeline-link pipeline-link--primary" href="subscribe/index.html">See the plan ladder</a>
+        <a class="pipeline-link pipeline-link--secondary" href="https://portal.3dvr.tech/start/" target="_blank" rel="noopener">Open the portal start flow</a>
       </div>
     </div>
   </section>

--- a/subscribe/index.html
+++ b/subscribe/index.html
@@ -99,6 +99,31 @@
     .section-intro { margin-top: 3rem; }
     .section-intro h3 { font-family: Poppins, sans-serif; font-size: 1.5rem; margin-bottom: 0.75rem; }
     .section-intro p { color: var(--muted); line-height: 1.6; max-width: 760px; }
+    .journey-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; margin-top: 1.25rem; }
+    .journey-card {
+      background: var(--panel);
+      border-radius: 14px;
+      padding: 1.1rem;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      display: grid;
+      gap: 0.65rem;
+    }
+    .journey-step {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: fit-content;
+      padding: 0.35rem 0.65rem;
+      border-radius: 999px;
+      background: var(--accent-soft);
+      color: var(--accent);
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .journey-card h4 { font-family: Poppins, sans-serif; font-size: 1.05rem; }
+    .journey-card p { color: var(--muted); line-height: 1.55; }
     details { background: var(--panel); border-radius: 12px; padding: 0.9rem 1rem; margin: 0.6rem 0; }
     details[open] { background: var(--panel-hover); }
     summary { cursor: pointer; font-weight: 700; }
@@ -274,6 +299,37 @@
           </div>
           <div class="notice">Best route into Enterprise when coordination pain is shared across a real team.</div>
         </article>
+      </div>
+    </section>
+
+    <section id="journey" class="section-intro">
+      <h3>What happens after you click</h3>
+      <p>Choose the plan here, continue in portal billing or free start, and keep the same account through onboarding, support, and delivery.</p>
+      <div class="journey-grid">
+        <article class="journey-card">
+          <span class="journey-step">Step 1</span>
+          <h4>Pick the right lane</h4>
+          <p>Use the plan cards and business-type pages to decide whether this is Free, Founder, Builder, Enterprise, or custom scope.</p>
+        </article>
+        <article class="journey-card">
+          <span class="journey-step">Step 2</span>
+          <h4>Continue in portal</h4>
+          <p>Paid plans route into portal billing and Free routes into the portal start flow, so the next move stays obvious.</p>
+        </article>
+        <article class="journey-card">
+          <span class="journey-step">Step 3</span>
+          <h4>Keep one account</h4>
+          <p>The same portal account handles free access, upgrades, invoices, support, and later plan changes.</p>
+        </article>
+        <article class="journey-card">
+          <span class="journey-step">Step 4</span>
+          <h4>Start the customer journey</h4>
+          <p>After signup, move into the portal start flow, projects, and direct support instead of starting over somewhere else.</p>
+        </article>
+      </div>
+      <div class="actions">
+        <a class="cta secondary" data-portal-path="/start/" href="https://portal.3dvr.tech/start/" target="_blank" rel="noopener">Open portal start</a>
+        <a class="cta secondary" data-preserve-portal-origin href="/launch-your-site.html">Talk through custom scope</a>
       </div>
     </section>
 

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -29,6 +29,12 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /Build your website or app/);
     assert.match(html, /Help you figure out the offer/);
     assert.match(html, /Stay with you as it grows/);
+    assert.match(html, /From lead generation to customer journey/);
+    assert.match(html, /Find the fit/);
+    assert.match(html, /Raise your hand/);
+    assert.match(html, /Continue in portal/);
+    assert.match(html, /Onboard and deliver/);
+    assert.match(html, /Open the portal start flow/);
     assert.doesNotMatch(html, /Use Life to log/);
     assert.doesNotMatch(html, /Join a Cell/);
     assert.doesNotMatch(html, /Life starter/);
@@ -62,6 +68,11 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /See local-service fit/);
     assert.match(html, /See Enterprise fit/);
     assert.match(html, /Daily check-ins and weekly reflection/);
+    assert.match(html, /What happens after you click/);
+    assert.match(html, /Pick the right lane/);
+    assert.match(html, /Keep one account/);
+    assert.match(html, /Start the customer journey/);
+    assert.match(html, /Open portal start/);
     assert.match(html, /No credit card required\. Create one portal account and start organizing what matters\./);
     assert.match(html, /Start Free in Portal/);
     assert.match(html, /Continue to Portal for \$5/);


### PR DESCRIPTION
## Summary
- add a homepage section that explains the path from lead generation to onboarding
- add a post-click journey section on the plans page so the portal handoff is explicit
- extend customer journey coverage for the new public funnel copy

## Testing
- node --test tests/customer-journey.test.js