### PR TITLE
Tighten homepage customer journey copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -1268,7 +1268,7 @@
           <div class="hero-spark hero-spark--bottom"></div>
           <img src="3DVR.png" alt="" />
           <p>
-            A clear place to land when you need a site, support, or a launch plan.
+            A place to land when you need a site, support, or a launch plan.
           </p>
         </div>
       </div>

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -8,7 +8,7 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /Websites\. Apps\. Direct support\./);
     assert.match(html, /We help small businesses actually launch\./);
     assert.match(html, /Not just plan\. Not just think about it\./);
-    assert.match(html, /A clear place to land when you need a site, support, or a launch plan\./);
+    assert.match(html, /A place to land when you need a site, support, or a launch plan\./);
     assert.match(html, /Get a site, landing page, or simple business system with direct help from idea to launch\./);
     assert.match(html, /Start Free/);
     assert.match(html, /Start free/);
@@ -44,6 +44,7 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /Get ongoing help shaping the idea, page, or offer and getting it launched\./);
     assert.match(html, /Best for growing businesses that need a site, follow-up, updates, and calmer operations\./);
     assert.match(html, /Best for support teams, organizations, and shared workflows that need one calmer operating lane\./);
+    assert.doesNotMatch(html, /A clear place to land when you need a site, support, or a launch plan\./);
     assert.doesNotMatch(html, /Websites\. Apps\. Real support\./);
     assert.doesNotMatch(html, /A real place to land when you need a site, support, or a launch plan\./);
     assert.doesNotMatch(html, /Best for real businesses that need a site, follow-up, updates, and calmer operations\./);


### PR DESCRIPTION
## Summary
- remove the extra "clear" from the homepage hero line so it reads more naturally
- update the matching customer journey assertion to keep the homepage copy locked in

## Verification
- `git diff --check origin/main...HEAD`
- `node --test tests/customer-journey.test.js`
