### PR TITLE
Tighten homepage plan chip copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -1311,7 +1311,7 @@
           <span id="heroFeedbackStatus" class="hero-feedback__status">Anonymous feedback helps tune the homepage.</span>
         </div>
         <div class="hero-plan-dock" aria-label="Quick plan links">
-          <span class="hero-plan-dock__label">Choose a lane, continue in portal</span>
+          <span class="hero-plan-dock__label">Pick the lane that fits. Billing and account setup continue in portal.</span>
           <div class="hero-plan-dock__grid">
             <a
               class="hero-plan-chip"
@@ -1320,7 +1320,7 @@
               href="https://portal.3dvr.tech/free-trial.html"
             >
               <strong>Free</strong>
-              <span>Start in portal</span>
+              <span>Get organized first</span>
             </a>
             <a
               class="hero-plan-chip"
@@ -1329,7 +1329,7 @@
               href="https://portal.3dvr.tech/billing/?plan=pro"
             >
               <strong>$20</strong>
-              <span>Continue in portal</span>
+              <span>Launch with direct help</span>
             </a>
             <a
               class="hero-plan-chip"
@@ -1338,7 +1338,7 @@
               href="https://portal.3dvr.tech/billing/?plan=builder"
             >
               <strong>$50</strong>
-              <span>Continue in portal</span>
+              <span>Build the business lane</span>
             </a>
             <a
               class="hero-plan-chip"
@@ -1347,7 +1347,7 @@
               href="https://portal.3dvr.tech/billing/?plan=embedded"
             >
               <strong>$200</strong>
-              <span>Continue in portal</span>
+              <span>Run one calmer team system</span>
             </a>
             <a
               class="hero-plan-chip"
@@ -1356,7 +1356,7 @@
               href="https://portal.3dvr.tech/billing/?plan=custom"
             >
               <strong>Custom</strong>
-              <span>Bigger scope</span>
+              <span>Talk through the bigger scope</span>
             </a>
           </div>
         </div>

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -16,9 +16,13 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /data-portal-path="\/billing\/\?plan=pro"/);
     assert.match(html, /data-portal-path="\/billing\/\?plan=builder"/);
     assert.match(html, /data-portal-path="\/billing\/\?plan=embedded"/);
-    assert.match(html, /Choose a lane, continue in portal/);
+    assert.match(html, /Pick the lane that fits\. Billing and account setup continue in portal\./);
     assert.match(html, /Built for/);
-    assert.match(html, /Start in portal/);
+    assert.match(html, /Get organized first/);
+    assert.match(html, /Launch with direct help/);
+    assert.match(html, /Build the business lane/);
+    assert.match(html, /Run one calmer team system/);
+    assert.match(html, /Talk through the bigger scope/);
     assert.match(html, /\$20/);
     assert.match(html, /\$50/);
     assert.match(html, /\$200/);
@@ -38,6 +42,7 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /Continue in portal/);
     assert.match(html, /Onboard and deliver/);
     assert.match(html, /Open the portal start flow/);
+    assert.doesNotMatch(html, /Choose a lane, continue in portal/);
     assert.doesNotMatch(html, /Use Life to log/);
     assert.doesNotMatch(html, /Join a Cell/);
     assert.doesNotMatch(html, /Life starter/);


### PR DESCRIPTION
## Summary
- rewrite the homepage plan dock label so the portal handoff is explained once at the section level
- give each homepage plan chip a more marketing-oriented outcome line instead of repeating "Continue in portal"
- update the homepage customer-journey regression to cover the new copy

## Testing
- node --test tests/customer-journey.test.js tests/homepage-growth.test.js