### PR TITLE
Tighten traction support line

### DIFF
--- a/growth/homepage-experiment.js
+++ b/growth/homepage-experiment.js
@@ -35,7 +35,7 @@
       key: 'traction',
       eyebrow: 'Launch faster. Start selling.',
       primary: 'Get your project live.',
-      secondary: 'Keep moving with direct support.',
+      secondary: 'Keep it moving with direct support.',
       body: '3dvr helps small businesses and creators launch pages, apps, and follow-up systems without getting stuck in tech.',
       feedbackPrompt: 'Does this version make you want to reach out?',
     }),

--- a/tests/homepage-growth.test.js
+++ b/tests/homepage-growth.test.js
@@ -44,6 +44,8 @@ test('homepage ships Gun-backed experiment and feedback plumbing', async () => {
   assert.match(js, /EXPERIMENT_CONFIG_PATH = \['3dvr-portal', 'growth', 'experiments', 'homepage-hero', 'config'\]/);
   assert.match(js, /EXPERIMENT_EVENT_PATH = \['3dvr-portal', 'growth', 'experiments', 'homepage-hero', 'events'\]/);
   assert.match(js, /FEEDBACK_EVENT_PATH = \['3dvr-portal', 'growth', 'feedback', 'homepage-hero'\]/);
+  assert.match(js, /primary: 'Get your project live\.'/);
+  assert.match(js, /secondary: 'Keep it moving with direct support\.'/);
   assert.match(js, /function chooseVariant/);
   assert.match(js, /function applyVariant/);
   assert.match(js, /function logView/);


### PR DESCRIPTION
## Summary
- update the homepage traction experiment line from `Keep moving with direct support.` to `Keep it moving with direct support.`
- add a regression assertion for the traction experiment copy so the shorter wording stays locked in

## Testing
- node --test tests/homepage-growth.test.js tests/customer-journey.test.js