### PR TITLE
Shorten traction eyebrow

### DIFF
--- a/growth/homepage-experiment.js
+++ b/growth/homepage-experiment.js
@@ -33,7 +33,7 @@
     }),
     traction: Object.freeze({
       key: 'traction',
-      eyebrow: 'Launch faster. Start selling.',
+      eyebrow: 'Launch fast. Start selling.',
       primary: 'Get your project live.',
       secondary: 'Keep it moving with direct support.',
       body: '3dvr helps small businesses and creators launch pages, apps, and follow-up systems without getting stuck in tech.',

--- a/tests/homepage-growth.test.js
+++ b/tests/homepage-growth.test.js
@@ -44,6 +44,7 @@ test('homepage ships Gun-backed experiment and feedback plumbing', async () => {
   assert.match(js, /EXPERIMENT_CONFIG_PATH = \['3dvr-portal', 'growth', 'experiments', 'homepage-hero', 'config'\]/);
   assert.match(js, /EXPERIMENT_EVENT_PATH = \['3dvr-portal', 'growth', 'experiments', 'homepage-hero', 'events'\]/);
   assert.match(js, /FEEDBACK_EVENT_PATH = \['3dvr-portal', 'growth', 'feedback', 'homepage-hero'\]/);
+  assert.match(js, /eyebrow: 'Launch fast\. Start selling\.'/);
   assert.match(js, /primary: 'Get your project live\.'/);
   assert.match(js, /secondary: 'Keep it moving with direct support\.'/);
   assert.match(js, /function chooseVariant/);


### PR DESCRIPTION
## Summary
- change the homepage traction experiment eyebrow from `Launch faster. Start selling.` to `Launch fast. Start selling.`
- extend the homepage growth test so the shorter eyebrow stays locked in

## Testing
- node --test tests/homepage-growth.test.js tests/customer-journey.test.js