### PR TITLE
Refresh web assets before using cache

### DIFF
--- a/pwa.js
+++ b/pwa.js
@@ -118,9 +118,11 @@
 
   if (supportsServiceWorker) {
     window.addEventListener('load', () => {
-      navigator.serviceWorker.register('/service-worker.js').catch((error) => {
-        console.error('Service worker registration failed:', error);
-      });
+      navigator.serviceWorker.register('/service-worker.js')
+        .then((registration) => registration.update().catch(() => {}))
+        .catch((error) => {
+          console.error('Service worker registration failed:', error);
+        });
     });
   } else {
     ensureButtonExists();

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,21 +1,24 @@
-const CACHE_NAME = '3dvr-cache-v2';
+const CACHE_NAME = '3dvr-cache-v3';
 const OFFLINE_ASSETS = [
   '/',
   '/index.html',
   '/3DVR.png',
   '/3DVRfavicon.png'
 ];
-const CACHEABLE_EXTENSIONS = [
+const NETWORK_FIRST_EXTENSIONS = [
+  '.css',
+  '.js',
+  '.json',
+  '.webmanifest',
+  '.txt'
+];
+const CACHE_FIRST_EXTENSIONS = [
   '.png',
   '.jpg',
   '.jpeg',
   '.gif',
   '.svg',
   '.webp',
-  '.css',
-  '.js',
-  '.json',
-  '.webmanifest',
   '.woff',
   '.woff2'
 ];
@@ -44,7 +47,20 @@ function isHtmlNavigationRequest(request) {
   );
 }
 
-function isCacheableAssetRequest(request) {
+function isNetworkFirstAssetRequest(request) {
+  if (!isSameOrigin(request) || isHtmlNavigationRequest(request)) {
+    return false;
+  }
+
+  const url = requestUrl(request);
+  if (!url) {
+    return false;
+  }
+
+  return NETWORK_FIRST_EXTENSIONS.some(extension => url.pathname.endsWith(extension));
+}
+
+function isCacheFirstAssetRequest(request) {
   if (!isSameOrigin(request) || isHtmlNavigationRequest(request)) {
     return false;
   }
@@ -58,7 +74,7 @@ function isCacheableAssetRequest(request) {
     return true;
   }
 
-  return CACHEABLE_EXTENSIONS.some(extension => url.pathname.endsWith(extension));
+  return CACHE_FIRST_EXTENSIONS.some(extension => url.pathname.endsWith(extension));
 }
 
 async function cacheResponse(request, response) {
@@ -71,7 +87,7 @@ async function cacheResponse(request, response) {
   return response;
 }
 
-async function networkFirstResponse(request) {
+async function networkFirstResponse(request, { offlineFallbackPath = '' } = {}) {
   try {
     const response = await fetch(request);
     return await cacheResponse(request, response);
@@ -81,7 +97,17 @@ async function networkFirstResponse(request) {
       return cached;
     }
 
-    return caches.match('/index.html');
+    if (offlineFallbackPath) {
+      const offlineFallback = await caches.match(offlineFallbackPath);
+      if (offlineFallback) {
+        return offlineFallback;
+      }
+    }
+
+    return new Response('Offline', {
+      status: 503,
+      statusText: 'Offline'
+    });
   }
 }
 
@@ -115,11 +141,16 @@ self.addEventListener('fetch', (event) => {
   }
 
   if (isHtmlNavigationRequest(event.request)) {
+    event.respondWith(networkFirstResponse(event.request, { offlineFallbackPath: '/index.html' }));
+    return;
+  }
+
+  if (isNetworkFirstAssetRequest(event.request)) {
     event.respondWith(networkFirstResponse(event.request));
     return;
   }
 
-  if (isCacheableAssetRequest(event.request)) {
+  if (isCacheFirstAssetRequest(event.request)) {
     event.respondWith(cacheFirstResponse(event.request));
   }
 });

--- a/tests/service-worker.test.js
+++ b/tests/service-worker.test.js
@@ -4,7 +4,7 @@ import path from 'node:path';
 import test from 'node:test';
 import vm from 'node:vm';
 
-const serviceWorkerPath = '/data/data/com.termux/files/home/3dvr-web-billing-center/service-worker.js';
+const serviceWorkerPath = '/data/data/com.termux/files/home/3dvr-web/service-worker.js';
 
 async function loadServiceWorker({
   cacheMatch,
@@ -120,9 +120,9 @@ test('service worker uses network-first for html navigations', async () => {
   assert.equal(cachePuts.length, 1);
 });
 
-test('service worker keeps same-origin js assets cache-first', async () => {
+test('service worker uses network-first for same-origin js assets', async () => {
   let fetchCalls = 0;
-  const { listeners } = await loadServiceWorker({
+  const { listeners, cachePuts } = await loadServiceWorker({
     cacheMatch: async (request) => {
       if (request?.url === 'https://www.3dvr.tech/subscribe/portal-links.js') {
         return new Response('cached-js', { status: 200 });
@@ -142,6 +142,54 @@ test('service worker keeps same-origin js assets cache-first', async () => {
     })
   );
 
-  assert.equal(fetchCalls, 0);
+  assert.equal(fetchCalls, 1);
+  assert.equal(await response.text(), 'network-js');
+  assert.equal(cachePuts.length, 1);
+});
+
+test('service worker falls back to cached js assets when offline', async () => {
+  const { listeners } = await loadServiceWorker({
+    cacheMatch: async (request) => {
+      if (request?.url === 'https://www.3dvr.tech/subscribe/portal-links.js') {
+        return new Response('cached-js', { status: 200 });
+      }
+      return undefined;
+    },
+    fetchImpl: async () => {
+      throw new Error('offline');
+    }
+  });
+
+  const response = await dispatchFetch(
+    listeners,
+    createRequest('https://www.3dvr.tech/subscribe/portal-links.js', {
+      accept: 'text/javascript'
+    })
+  );
+
   assert.equal(await response.text(), 'cached-js');
+});
+
+test('service worker keeps same-origin image assets cache-first', async () => {
+  let fetchCalls = 0;
+  const { listeners } = await loadServiceWorker({
+    cacheMatch: async (request) => {
+      if (request?.url === 'https://www.3dvr.tech/3DVR.png') {
+        return new Response('cached-image', { status: 200 });
+      }
+      return undefined;
+    },
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      return new Response('network-image', { status: 200 });
+    }
+  });
+
+  const response = await dispatchFetch(
+    listeners,
+    createRequest('https://www.3dvr.tech/3DVR.png')
+  );
+
+  assert.equal(fetchCalls, 0);
+  assert.equal(await response.text(), 'cached-image');
 });


### PR DESCRIPTION
## Summary
- switch the web service worker to network-first for html, js, css, json, and manifest assets so Brave sees deploy changes without manual cache clears
- keep image and font assets cache-first for offline/perf wins
- make the service worker test cover the actual `3dvr-web` worker and add coverage for the new cache strategy

## Testing
- node --test tests/service-worker.test.js tests/homepage-growth.test.js tests/customer-journey.test.js