### PR TITLE
Add Pocket Workstation install page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1807,6 +1807,7 @@
           </ul>
           <div class="nomad-actions">
             <a class="cta" href="nomad-system.html" data-growth-cta="explore-nomad-system">Explore the nomad system</a>
+            <a class="cta" href="pocket-workstation.html" data-growth-cta="pocket-workstation-page">Pocket Workstation install</a>
             <a class="nomad-link" href="vision/index.html">
               Read the broader vision
               <i class="fa-solid fa-arrow-right" aria-hidden="true"></i>

--- a/install.sh
+++ b/install.sh
@@ -68,13 +68,10 @@ const Gun = require(gunPath);
 console.log = originalLog;
 console.warn = originalWarn;
 
-const identityKey = String(process.argv[2] || '').trim();
-const recordType = String(process.argv[3] || 'commands').trim();
-
-if (!identityKey) {
-  process.stdout.write('[]');
-  process.exit(0);
-}
+const mode = String(process.argv[2] || 'records').trim();
+const identityKey = String(process.argv[3] || '').trim();
+const recordType = String(process.argv[4] || 'commands').trim();
+const pairingCode = String(process.argv[5] || '').trim().toUpperCase();
 
 const gun = Gun({
   peers: [
@@ -87,30 +84,57 @@ const gun = Gun({
   localStorage: false
 });
 
-const node = gun
-  .get('3dvr-portal')
-  .get('pocketWorkstation')
-  .get('users')
-  .get(identityKey)
-  .get(recordType);
-
-const records = new Map();
-const subscription = node.map().on((data, key) => {
-  if (!data || key === '_' || typeof data !== 'object') {
-    return;
+if (mode === 'pairing') {
+  if (!pairingCode) {
+    process.stdout.write('{}');
+    process.exit(0);
   }
-  const id = String(data.id || key);
-  records.set(id, { ...data, id });
-});
 
-setTimeout(() => {
-  if (subscription && typeof subscription.off === 'function') {
-    subscription.off();
+  gun
+    .get('3dvr-portal')
+    .get('pocketWorkstation')
+    .get('pairing')
+    .get(pairingCode)
+    .once(data => {
+      process.stdout.write(JSON.stringify(data || {}));
+      process.exit(0);
+    });
+
+  setTimeout(() => {
+    process.stdout.write('{}');
+    process.exit(0);
+  }, 2200);
+} else {
+  if (!identityKey) {
+    process.stdout.write('[]');
+    process.exit(0);
   }
-  const ordered = Array.from(records.values()).sort((a, b) => Number(b.updatedAt || 0) - Number(a.updatedAt || 0));
-  process.stdout.write(JSON.stringify(ordered));
-  process.exit(0);
-}, 2200);
+
+  const node = gun
+    .get('3dvr-portal')
+    .get('pocketWorkstation')
+    .get('users')
+    .get(identityKey)
+    .get(recordType);
+
+  const records = new Map();
+  const subscription = node.map().on((data, key) => {
+    if (!data || key === '_' || typeof data !== 'object') {
+      return;
+    }
+    const id = String(data.id || key);
+    records.set(id, { ...data, id });
+  });
+
+  setTimeout(() => {
+    if (subscription && typeof subscription.off === 'function') {
+      subscription.off();
+    }
+    const ordered = Array.from(records.values()).sort((a, b) => Number(b.updatedAt || 0) - Number(a.updatedAt || 0));
+    process.stdout.write(JSON.stringify(ordered));
+    process.exit(0);
+  }, 2200);
+}
 EOF
 
 chmod +x "${FETCHER_PATH}"
@@ -136,6 +160,19 @@ normalize_alias() {
   printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
 }
 
+normalize_code() {
+  printf '%s' "$1" | tr '[:lower:]' '[:upper:]' | tr -cd 'A-Z0-9' | cut -c1-6
+}
+
+generate_pair_code() {
+  python3 - <<'PY'
+import random
+
+alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+print("".join(random.choice(alphabet) for _ in range(6)))
+PY
+}
+
 save_config() {
   cat > "${CONFIG_PATH}" <<CONFIG
 THREEDVR_ALIAS="${THREEDVR_ALIAS:-}"
@@ -156,9 +193,37 @@ open_url() {
   if command -v termux-open-url >/dev/null 2>&1; then
     termux-open-url "${url}" >/dev/null 2>&1 || true
     printf '%s\n' "${url}"
-    exit 0
+    return 0
   fi
   printf '%s\n' "${url}"
+}
+
+poll_pairing_code() {
+  pair_code="$1"
+  pair_cache="${CACHE_DIR}/pairing-${pair_code}.json"
+
+  for _attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
+    node "${FETCHER_PATH}" "pairing" "_" "_" "${pair_code}" > "${pair_cache}"
+    if python3 - "${pair_cache}" <<'PY'
+import json
+import pathlib
+import sys
+
+cache_file = pathlib.Path(sys.argv[1])
+data = json.loads(cache_file.read_text()) if cache_file.exists() else {}
+if data.get('identityKey'):
+    print(data.get('alias', ''))
+    print(data.get('identityKey', ''))
+    raise SystemExit(0)
+raise SystemExit(1)
+PY
+    then
+      return 0
+    fi
+    sleep 5
+  done
+
+  return 1
 }
 
 print_records() {
@@ -217,7 +282,7 @@ pull_records() {
   record_type="$1"
   need_identity
   cache_file="${CACHE_DIR}/${record_type}.json"
-  node "${FETCHER_PATH}" "${THREEDVR_IDENTITY_KEY}" "${record_type}" > "${cache_file}"
+  node "${FETCHER_PATH}" "records" "${THREEDVR_IDENTITY_KEY}" "${record_type}" > "${cache_file}"
   print_records "${record_type}" "${cache_file}"
 }
 
@@ -226,7 +291,7 @@ show_help() {
 3dvr Pocket Workstation CLI
 
 Usage:
-  3dvr connect <email-or-alias>
+  3dvr connect [email-or-alias]
   3dvr whoami
   3dvr open [portal|workstation|notes|commands|projects]
   3dvr notes
@@ -235,6 +300,7 @@ Usage:
   3dvr deploy
 
 Examples:
+  3dvr connect
   3dvr connect you@example.com
   3dvr commands pull
   3dvr deploy
@@ -251,7 +317,37 @@ case "${command_name}" in
   connect)
     alias_value="${1:-}"
     if [ -z "${alias_value}" ]; then
-      echo "Usage: 3dvr connect <email-or-alias>" >&2
+      pair_code="$(generate_pair_code)"
+      pair_url="${PORTAL_ORIGIN}/pocket-workstation/?pairCode=${pair_code}#connect-title"
+      echo "Open this link on a signed-in portal session and enter the code:"
+      echo "${pair_code}"
+      open_url "${pair_url}"
+      echo "Waiting for Pocket Workstation to link the code..."
+      if poll_pairing_code "${pair_code}"; then
+        pair_cache="${CACHE_DIR}/pairing-${pair_code}.json"
+        THREEDVR_ALIAS="$(python3 - "${pair_cache}" <<'PY'
+import json
+import pathlib
+import sys
+data = json.loads(pathlib.Path(sys.argv[1]).read_text())
+print(data.get('alias', ''))
+PY
+)"
+        THREEDVR_IDENTITY_KEY="$(python3 - "${pair_cache}" <<'PY'
+import json
+import pathlib
+import sys
+data = json.loads(pathlib.Path(sys.argv[1]).read_text())
+print(data.get('identityKey', ''))
+PY
+)"
+        save_config
+        echo "Connected Pocket Workstation identity: ${THREEDVR_ALIAS}"
+        echo "Next step: 3dvr commands pull"
+        exit 0
+      fi
+      echo "No pairing response yet."
+      echo "Keep the portal open at ${pair_url} and try: 3dvr connect"
       exit 1
     fi
     THREEDVR_ALIAS="$(normalize_alias "${alias_value}")"
@@ -303,7 +399,7 @@ case "${command_name}" in
   deploy)
     need_identity
     cache_file="${CACHE_DIR}/commands.json"
-    node "${FETCHER_PATH}" "${THREEDVR_IDENTITY_KEY}" "commands" > "${cache_file}"
+    node "${FETCHER_PATH}" "records" "${THREEDVR_IDENTITY_KEY}" "commands" > "${cache_file}"
     python3 - "${cache_file}" <<'PY'
 import json
 import pathlib
@@ -351,5 +447,5 @@ fi
 
 printf '\n[3dvr] Install complete.\n'
 printf '[3dvr] Open the dashboard: %s/pocket-workstation/\n' "${PORTAL_ORIGIN}"
-printf '[3dvr] Connect your identity: 3dvr connect your@email.com\n'
+printf '[3dvr] Connect your identity: 3dvr connect\n'
 printf '[3dvr] Pull your commands: 3dvr commands pull\n'

--- a/pocket-workstation.html
+++ b/pocket-workstation.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3dvr Pocket Workstation</title>
+  <meta
+    name="description"
+    content="Turn your phone into a builder console with the 3dvr Pocket Workstation: notes, commands, projects, and a Termux install flow."
+  />
+  <style>
+    :root {
+      --bg: #08111a;
+      --bg-soft: #112030;
+      --panel: rgba(255, 255, 255, 0.08);
+      --line: rgba(255, 255, 255, 0.12);
+      --text: #f5f8fb;
+      --muted: #bdd0e4;
+      --signal: #8fffd1;
+      --accent: #ffb867;
+      --shadow: 0 20px 60px rgba(0, 0, 0, 0.28);
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font-family: Inter, Arial, sans-serif;
+      color: var(--text);
+      background:
+        radial-gradient(circle at top left, rgba(143, 255, 209, 0.18), transparent 25%),
+        linear-gradient(180deg, #0a1520 0%, #08111a 48%, #05090f 100%);
+      line-height: 1.65;
+    }
+
+    a { color: inherit; text-decoration: none; }
+
+    .shell {
+      width: min(1100px, calc(100% - 1.5rem));
+      margin: 0 auto;
+    }
+
+    .hero,
+    .section {
+      padding: 4.5rem 0;
+    }
+
+    .hero-grid,
+    .two-up,
+    .steps {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .hero-grid,
+    .two-up {
+      grid-template-columns: minmax(0, 1.15fr) minmax(280px, 0.85fr);
+      align-items: start;
+    }
+
+    .eyebrow {
+      display: inline-block;
+      margin-bottom: 1rem;
+      color: var(--signal);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 0.82rem;
+      font-weight: 700;
+    }
+
+    h1, h2, h3 {
+      margin-top: 0;
+      line-height: 1.02;
+    }
+
+    h1 {
+      font-size: clamp(2.6rem, 7vw, 5rem);
+      margin-bottom: 1rem;
+    }
+
+    h2 {
+      font-size: clamp(2rem, 4vw, 3rem);
+      margin-bottom: 0.85rem;
+    }
+
+    p {
+      color: var(--muted);
+      margin-top: 0;
+    }
+
+    .panel,
+    .step-card,
+    .command-card {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 24px;
+      box-shadow: var(--shadow);
+    }
+
+    .panel {
+      padding: 1.35rem;
+    }
+
+    .button-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.85rem;
+      margin-top: 1.4rem;
+    }
+
+    .button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 50px;
+      padding: 0.9rem 1.2rem;
+      border-radius: 999px;
+      font-weight: 800;
+    }
+
+    .button-primary {
+      background: linear-gradient(135deg, var(--signal), #d9ff7d);
+      color: #04110c;
+    }
+
+    .button-secondary {
+      background: rgba(255, 255, 255, 0.04);
+      border: 1px solid var(--line);
+    }
+
+    .command-card {
+      padding: 1.1rem;
+    }
+
+    .command-card code {
+      display: block;
+      padding: 1rem;
+      border-radius: 16px;
+      background: rgba(0, 0, 0, 0.28);
+      color: #c7fff0;
+      white-space: pre-wrap;
+      word-break: break-word;
+      margin: 0.85rem 0;
+    }
+
+    .steps {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .step-card {
+      padding: 1.2rem;
+    }
+
+    .step-card strong {
+      display: block;
+      margin-bottom: 0.4rem;
+      color: var(--text);
+    }
+
+    .list {
+      margin: 0;
+      padding-left: 1.1rem;
+      color: var(--muted);
+    }
+
+    .foot {
+      padding: 0 0 2.5rem;
+      color: var(--muted);
+      text-align: center;
+    }
+
+    @media (max-width: 900px) {
+      .hero-grid,
+      .two-up,
+      .steps {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <section class="hero">
+      <div class="shell hero-grid">
+        <div>
+          <p class="eyebrow">3dvr Pocket Workstation</p>
+          <h1>Turn your phone into a builder console.</h1>
+          <p>
+            Pocket Workstation gives you one portable place for notes, commands, projects, and guided next steps.
+            It works in the browser right now and can bootstrap a real Termux setup on Android.
+          </p>
+          <div class="button-row">
+            <a class="button button-primary" href="https://www.3dvr.tech/install">Copy the install route</a>
+            <a class="button button-secondary" href="https://portal.3dvr.tech/pocket-workstation/">Open the dashboard</a>
+          </div>
+        </div>
+        <aside class="command-card">
+          <h2>Install in Termux</h2>
+          <p>Run this once on Android inside Termux:</p>
+          <code>curl -s https://3dvr.tech/install | bash</code>
+          <p>
+            Then run <code>3dvr connect</code> and link the short code in the Pocket Workstation dashboard.
+          </p>
+        </aside>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="shell">
+        <div class="two-up">
+          <div class="panel">
+            <p class="eyebrow">What it does</p>
+            <h2>Simple first. Useful immediately.</h2>
+            <ul class="list">
+              <li>Save notes for deployments, ideas, and live project context.</li>
+              <li>Save reusable commands so you do not keep rebuilding your memory from scratch.</li>
+              <li>Track projects and the next action that moves them forward.</li>
+              <li>Use the lightweight helper to turn “I need to deploy this” into concrete steps.</li>
+            </ul>
+          </div>
+          <div class="panel">
+            <p class="eyebrow">Why it matters</p>
+            <h2>One system across devices.</h2>
+            <ul class="list">
+              <li>Android gets local power through Termux.</li>
+              <li>iPhone gets the same dashboard as a clean control panel.</li>
+              <li>Desktop gets the same workspace with more room.</li>
+              <li>The center stays your projects, not a generic terminal toy.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="shell">
+        <p class="eyebrow">How it works</p>
+        <h2>Three clear steps</h2>
+        <div class="steps">
+          <article class="step-card">
+            <strong>1. Install</strong>
+            Run the one-line install command in Termux.
+          </article>
+          <article class="step-card">
+            <strong>2. Connect</strong>
+            Run <code>3dvr connect</code>, then approve the short code in the dashboard.
+          </article>
+          <article class="step-card">
+            <strong>3. Pull your setup</strong>
+            Use <code>3dvr commands pull</code> or <code>3dvr projects</code> to bring your workspace in.
+          </article>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="foot">
+    <div class="shell">
+      <p>3dvr Pocket Workstation v0.1</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -5,6 +5,8 @@ import { readFile } from 'node:fs/promises';
 test('Termux installer ships a real Pocket Workstation bootstrap flow', async () => {
   const installScript = await readFile(new URL('../install.sh', import.meta.url), 'utf8');
   const vercelConfig = await readFile(new URL('../vercel.json', import.meta.url), 'utf8');
+  const pageHtml = await readFile(new URL('../pocket-workstation.html', import.meta.url), 'utf8');
+  const homepageHtml = await readFile(new URL('../index.html', import.meta.url), 'utf8');
 
   assert.match(installScript, /^#!\/usr\/bin\/env bash/m);
   assert.match(installScript, /3dvr install is built for Termux on Android/);
@@ -13,15 +15,28 @@ test('Termux installer ships a real Pocket Workstation bootstrap flow', async ()
   assert.match(installScript, /THREEDVR_HOME="\$\{HOME\}\/\.3dvr"/);
   assert.match(installScript, /CLI_PATH="\$\{BIN_DIR\}\/3dvr"/);
   assert.match(installScript, /THREEDVR_IDENTITY_KEY="alias-\$\{THREEDVR_ALIAS\}"/);
+  assert.match(installScript, /pairCode=/);
+  assert.match(installScript, /poll_pairing_code/);
+  assert.match(installScript, /3dvr connect \[email-or-alias\]/);
   assert.match(installScript, /3dvr Pocket Workstation CLI/);
-  assert.match(installScript, /3dvr connect <email-or-alias>/);
+  assert.match(installScript, /3dvr connect$/m);
   assert.match(installScript, /3dvr commands pull/);
   assert.match(installScript, /3dvr deploy/);
   assert.match(installScript, /get\('3dvr-portal'\)\s*\.get\('pocketWorkstation'\)\s*\.get\('users'\)/);
+  assert.match(installScript, /get\('3dvr-portal'\)\s*\.get\('pocketWorkstation'\)\s*\.get\('pairing'\)/);
   assert.match(installScript, /Open the dashboard: %s\/pocket-workstation\//);
 
   assert.match(vercelConfig, /"source": "\/install"/);
   assert.match(vercelConfig, /"destination": "\/install\.sh"/);
   assert.match(vercelConfig, /"Content-Type"/);
   assert.match(vercelConfig, /text\/plain; charset=utf-8/);
+
+  assert.match(pageHtml, /Turn your phone into a builder console\./);
+  assert.match(pageHtml, /curl -s https:\/\/3dvr\.tech\/install \| bash/);
+  assert.match(pageHtml, /Then run <code>3dvr connect<\/code>/);
+  assert.match(pageHtml, /https:\/\/portal\.3dvr\.tech\/pocket-workstation\//);
+
+  assert.match(homepageHtml, /Pocket Workstation install/);
+  assert.match(homepageHtml, /href="pocket-workstation\.html"/);
+  assert.match(homepageHtml, /data-growth-cta="pocket-workstation-page"/);
 });


### PR DESCRIPTION
## Summary
- upgrade the Termux installer so `3dvr connect` can pair through a short code instead of requiring an alias
- add a plain-English Pocket Workstation page that explains the install and next steps
- link the new page from the homepage nomad section and extend installer coverage

## Verification
- `bash -n install.sh`
- `node --test tests/install-script.test.js`

## User-facing impact
Users can install from `https://3dvr.tech/install`, pair Termux through the portal, and read a cleaner explanation page on the web.