### PR TITLE
Use curl -Ls on Pocket Workstation install page

### DIFF
--- a/pocket-workstation.html
+++ b/pocket-workstation.html
@@ -197,7 +197,7 @@
         <aside class="command-card">
           <h2>Install in Termux</h2>
           <p>Run this once on Android inside Termux:</p>
-          <code>curl -s https://3dvr.tech/install | bash</code>
+          <code>curl -Ls https://3dvr.tech/install | bash</code>
           <p>
             Then run <code>3dvr connect</code> and link the short code in the Pocket Workstation dashboard.
           </p>

--- a/tests/install-script.test.js
+++ b/tests/install-script.test.js
@@ -32,7 +32,7 @@ test('Termux installer ships a real Pocket Workstation bootstrap flow', async ()
   assert.match(vercelConfig, /text\/plain; charset=utf-8/);
 
   assert.match(pageHtml, /Turn your phone into a builder console\./);
-  assert.match(pageHtml, /curl -s https:\/\/3dvr\.tech\/install \| bash/);
+  assert.match(pageHtml, /curl -Ls https:\/\/3dvr\.tech\/install \| bash/);
   assert.match(pageHtml, /Then run <code>3dvr connect<\/code>/);
   assert.match(pageHtml, /https:\/\/portal\.3dvr\.tech\/pocket-workstation\//);
 


### PR DESCRIPTION
## Summary
- update the public Pocket Workstation page to show the redirect-safe install command
- align the installer page test with the `curl -Ls` example

## Verification
- `node --test tests/install-script.test.js`

## User-facing impact
The public install page now shows the safest copy-paste command for the current domain setup.