### PR TITLE
Make Builder the default business lane

### DIFF
--- a/index.html
+++ b/index.html
@@ -1499,7 +1499,7 @@
               href="https://portal.3dvr.tech/billing/?plan=pro"
             >
               <strong>$20</strong>
-              <span>Launch with direct help</span>
+              <span>Launch in 3 Days</span>
             </a>
             <a
               class="hero-plan-chip"
@@ -1508,7 +1508,7 @@
               href="https://portal.3dvr.tech/billing/?plan=builder"
             >
               <strong>$50</strong>
-              <span>Build the business lane</span>
+              <span>Default for businesses</span>
             </a>
             <a
               class="hero-plan-chip"
@@ -1585,7 +1585,7 @@
       </div>
       <div class="vision-footnote">
         <p>
-          Start free if you need structure. Start at $20/month if you want launch help. Most businesses should move into Builder at $50/month. Teams with shared workflow pain should look at Enterprise at $200/month.
+          Start free if you need structure. Use Launch in 3 Days at $20/month for the first page or offer. Most active businesses should start on Builder at $50/month, with setup sprints available when you want the first workflow built faster. Teams with shared workflow pain should look at Enterprise at $200/month.
         </p>
         <a class="vision-link" href="subscribe/index.html">
           See plans and services
@@ -1690,7 +1690,7 @@
 
   <section id="subscribe" style="background: var(--bg-subscribe);">
     <h2>Simple ways to work together</h2>
-    <p>Start free if you need structure. Start at $20/month if you want direct launch help. Most businesses should start on Builder at $50/month. Teams with shared workflow pain should look at Enterprise at $200/month. Tap a card to continue in portal.</p>
+    <p>Start free if you need structure. Use Launch in 3 Days at $20/month for the first page or offer. If you already have real customers, quotes, follow-up, or weekly operations to manage, Builder at $50/month is the default business lane. Tap a card to continue in portal.</p>
     <div class="card-grid">
       <a
         class="card"
@@ -1707,7 +1707,7 @@
         href="https://portal.3dvr.tech/billing/?plan=pro"
       >
         <h3><span class="plan-name">Founder Plan</span><br><span class="plan-price">$20 monthly</span></h3>
-        <p>Get ongoing help shaping the idea, page, or offer and getting it launched.</p>
+        <p>Use this for Launch in 3 Days when the offer, site, or first page still needs to become real.</p>
         <span class="btn-like">Continue in Portal</span>
       </a>
       <a
@@ -1716,7 +1716,7 @@
         href="https://portal.3dvr.tech/billing/?plan=builder"
       >
         <h3><span class="plan-name">Builder Plan</span><br><span class="plan-price">$50 monthly</span></h3>
-        <p>Best for growing businesses that need a site, follow-up, updates, and calmer operations.</p>
+        <p>Default for active businesses that need a site, follow-up, updates, and calmer operations. Pair it with a setup sprint when you want the first workflow built faster.</p>
         <span class="btn-like">Continue in Portal</span>
       </a>
       <a

--- a/subscribe/index.html
+++ b/subscribe/index.html
@@ -79,6 +79,27 @@
     .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1.25rem; margin-top: 2rem; }
     .card { background: var(--panel); padding: 1.25rem; border-radius: 14px; transition: 0.25s; position: relative; display: flex; flex-direction: column; min-height: 100%; }
     .card:hover { background: var(--panel-hover); transform: translateY(-3px); }
+    .card.featured {
+      background:
+        linear-gradient(150deg, rgba(0, 255, 200, 0.18), rgba(255, 255, 255, 0.09)),
+        var(--panel);
+      border: 2px solid rgba(0, 255, 200, 0.68);
+      box-shadow: 0 24px 50px rgba(0, 0, 0, 0.28), 0 0 34px rgba(0, 255, 200, 0.18);
+    }
+    .card.featured::before {
+      content: "Default for active businesses";
+      display: inline-flex;
+      width: fit-content;
+      margin-bottom: 0.85rem;
+      padding: 0.35rem 0.65rem;
+      border-radius: 999px;
+      background: var(--accent);
+      color: #00110d;
+      font-size: 0.75rem;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
     .card h2 { font-family: Poppins, sans-serif; font-size: 1.2rem; color: var(--accent); margin-bottom: 0.4rem; }
     .card .tagline { color: var(--muted); font-size: 0.95rem; margin-bottom: 0.75rem; line-height: 1.5; }
     .price { font-size: 1.8rem; font-weight: 800; margin: 0.25rem 0 0.75rem; }
@@ -153,7 +174,7 @@
   <main>
     <section class="hero">
       <h1>Choose Your 3dvr.tech Plan</h1>
-      <p>Start free to get organized, support the mission at $5, grow with $20, move into a $50 builder lane, choose Enterprise at $200 for shared team support, or use custom scoped work.</p>
+      <p>Launch in 3 Days is the fast entry point. Builder at $50/month is the default business lane when you already have leads, customers, quotes, follow-up, or weekly operations to keep moving.</p>
       <p class="hero-helper">
         New here? Start with a plan below. Returning? <a data-portal-path="/billing/" href="https://portal.3dvr.tech/billing/" target="_blank" rel="noopener">Open the billing center</a>.
       </p>
@@ -200,7 +221,7 @@
       <!-- PRO -->
       <article id="pro" class="card">
         <h2>Founder Plan</h2>
-        <p class="tagline">Launch your brand with a custom domain (included if $10/yr or less) and get more support as your project grows.</p>
+        <p class="tagline">Use Founder for Launch in 3 Days when the first page, offer, or useful version still needs to become real.</p>
         <div class="price">$20 / month</div>
         <ul>
           <li>Done-for-you website & landing pages</li>
@@ -217,15 +238,15 @@
       </article>
 
       <!-- BUILDER -->
-      <article id="builder" class="card">
+      <article id="builder" class="card featured">
         <h2>Builder Plan</h2>
-        <p class="tagline">For deeper partnership, heavier execution, and a faster lane for roadmap work across the portal and client projects.</p>
+        <p class="tagline">The main lane for active businesses that need follow-up, site updates, CRM rhythm, and calmer operations with direct support.</p>
         <div class="price">$50 / month</div>
         <ul>
-          <li>Everything in the Founder Plan</li>
-          <li>Higher usage limits across premium portal tools</li>
+          <li>Everything in Founder for launch and offer support</li>
+          <li>Lead follow-up, CRM, calendar, and weekly operating rhythm</li>
           <li>Priority planning and implementation support</li>
-          <li>Faster access for heavier design and product work</li>
+          <li>Optional setup sprint when you want the first workflow built faster</li>
         </ul>
         <div class="actions">
           <a class="cta primary" data-portal-path="/billing/?plan=builder" href="https://portal.3dvr.tech/billing/?plan=builder" target="_blank" rel="noopener">✅ Continue to Portal for $50</a>

--- a/subscribe/local-services.html
+++ b/subscribe/local-services.html
@@ -185,7 +185,7 @@
         faster follow-up, clearer intake, and one operating lane for jobs already in motion.
       </p>
       <div class="price">Builder $50 / month</div>
-      <p class="hero-note">Best fit when the work is real, the owner is busy, and the main problem is keeping the week organized.</p>
+      <p class="hero-note">Default business lane when the work is real, the owner is busy, and the main problem is keeping the week organized. Add a setup sprint when the first workflow needs to move fast.</p>
       <div class="actions">
         <a class="cta primary" data-portal-path="/billing/?plan=builder" href="https://portal.3dvr.tech/billing/?plan=builder" target="_blank" rel="noopener">Continue to Portal for Builder</a>
         <a class="cta secondary" data-preserve-portal-origin href="../launch-in-3-days.html">See Launch in 3 Days</a>
@@ -216,7 +216,7 @@
         <li>You handle real estimates, bookings, or service requests every week.</li>
         <li>You are still in the field, so software needs to stay lightweight and obvious.</li>
         <li>You need one clear next-action loop for leads, jobs, and payments.</li>
-        <li>You want Builder as the main lane, with scoped sprint help when heavier setup is worth it.</li>
+        <li>You want Builder as the main lane, with scoped setup sprint help when heavier setup is worth it.</li>
       </ul>
     </section>
 

--- a/subscribe/professional-services.html
+++ b/subscribe/professional-services.html
@@ -185,7 +185,7 @@
         professional-service teams that need clearer follow-up, better weekly rhythm, and fewer dropped conversations.
       </p>
       <div class="price">Builder $50 / month</div>
-      <p class="hero-note">Best fit when you want more replies, steadier follow-up, and one place to run the week.</p>
+      <p class="hero-note">Default business lane when you want more replies, steadier follow-up, and one place to run the week. Add a setup sprint when you want the first workflow built faster.</p>
       <div class="actions">
         <a class="cta primary" data-portal-path="/billing/?plan=builder" href="https://portal.3dvr.tech/billing/?plan=builder" target="_blank" rel="noopener">Continue to Portal for Builder</a>
         <a class="cta secondary" data-preserve-portal-origin href="../launch-in-3-days.html">See Launch in 3 Days</a>
@@ -216,7 +216,7 @@
         <li>You are still close to sales and delivery at the same time.</li>
         <li>You already get inquiries, but follow-up is not consistent enough.</li>
         <li>You want a lighter operating system plus real help, not a bulky enterprise tool.</li>
-        <li>You want Builder first, with one-time sprint work available when heavier execution is needed.</li>
+        <li>You want Builder first, with one-time setup sprint work available when heavier execution is needed.</li>
       </ul>
     </section>
 

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -19,8 +19,8 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /Pick the lane that fits\. Billing and account setup continue in portal\./);
     assert.match(html, /Built for/);
     assert.match(html, /Get organized first/);
-    assert.match(html, /Launch with direct help/);
-    assert.match(html, /Build the business lane/);
+    assert.match(html, /Launch in 3 Days/);
+    assert.match(html, /Default for businesses/);
     assert.match(html, /Run one calmer team system/);
     assert.match(html, /Talk through the bigger scope/);
     assert.match(html, /\$20/);
@@ -50,11 +50,12 @@ describe('3dvr-web customer journey copy', () => {
     assert.doesNotMatch(html, /Join a Cell/);
     assert.doesNotMatch(html, /Life starter/);
     assert.match(html, /Simple ways to work together/);
-    assert.match(html, /Start free if you need structure\. Start at \$20\/month if you want direct launch help\./);
+    assert.match(html, /Start free if you need structure\. Use Launch in 3 Days at \$20\/month for the first page or offer\./);
     assert.match(html, /Tap a card to continue in portal\./);
     assert.match(html, /Teams with shared workflow pain should look at Enterprise at \$200\/month\./);
-    assert.match(html, /Get ongoing help shaping the idea, page, or offer and getting it launched\./);
-    assert.match(html, /Best for growing businesses that need a site, follow-up, updates, and calmer operations\./);
+    assert.match(html, /Use this for Launch in 3 Days when the offer, site, or first page still needs to become real\./);
+    assert.match(html, /Default for active businesses that need a site, follow-up, updates, and calmer operations\./);
+    assert.match(html, /Pair it with a setup sprint when you want the first workflow built faster\./);
     assert.match(html, /Best for support teams, organizations, and shared workflows that need one calmer operating lane\./);
     assert.match(html, /Launch in 3 Days/);
     assert.match(html, /\$20 starting point/);
@@ -102,7 +103,8 @@ describe('3dvr-web customer journey copy', () => {
 
   it('makes the main plans page explicit about continuing in the portal', async () => {
     const html = await readFile(new URL('../subscribe/index.html', import.meta.url), 'utf8');
-    assert.match(html, /Start free to get organized, support the mission at \$5, grow with \$20, move into a \$50 builder lane, choose Enterprise at \$200 for shared team support, or use custom scoped work\./);
+    assert.match(html, /Launch in 3 Days is the fast entry point\. Builder at \$50\/month is the default business lane/);
+    assert.match(html, /Default for active businesses/);
     assert.match(html, /Get organized, sort out your next steps, and start using the portal without paying first\./);
     assert.match(html, /Choose by business type/);
     assert.match(html, /See professional-services fit/);
@@ -152,9 +154,13 @@ describe('3dvr-web customer journey copy', () => {
 
     assert.match(professionalHtml, /For Professional Services/);
     assert.match(professionalHtml, /Keep warm leads moving without building a giant sales stack\./);
+    assert.match(professionalHtml, /Default business lane when you want more replies, steadier follow-up, and one place to run the week\./);
+    assert.match(professionalHtml, /one-time setup sprint work/);
     assert.match(professionalHtml, /Continue to Portal for Builder/);
     assert.match(localHtml, /For Local Services/);
     assert.match(localHtml, /Stop letting calls, quotes, and follow-up slip through the cracks\./);
+    assert.match(localHtml, /Default business lane when the work is real, the owner is busy, and the main problem is keeping the week organized\./);
+    assert.match(localHtml, /scoped setup sprint help/);
     assert.match(localHtml, /Continue to Portal for Builder/);
     assert.match(supportHtml, /For Support Teams/);
     assert.match(supportHtml, /Give the team one calmer system for people, follow-up, and weekly action\./);


### PR DESCRIPTION
## Summary
- reposition Builder $50/month as the default lane for active business buyers
- keep Launch in 3 Days as the fast entry hook
- add setup-sprint framing for professional services and local services
- update customer journey tests for the new positioning

## Testing
- `node --test tests/customer-journey.test.js tests/homepage-growth.test.js`

## Live checks
- `https://portal.3dvr.tech/billing/?plan=pro` returned 200
- `https://portal.3dvr.tech/billing/?plan=builder` returned 200
- `https://portal.3dvr.tech/billing/?plan=embedded` returned 200
- `https://portal.3dvr.tech/start/` returned 200