### PR TITLE
Frame custom as one-time payments

### DIFF
--- a/index.html
+++ b/index.html
@@ -1526,7 +1526,7 @@
               href="https://portal.3dvr.tech/billing/?plan=custom"
             >
               <strong>Custom</strong>
-              <span>Talk through the bigger scope</span>
+              <span>One-time payment or deposit</span>
             </a>
           </div>
         </div>
@@ -1612,7 +1612,7 @@
         <article class="pipeline-card">
           <span class="pipeline-step">Step 2</span>
           <h3>Raise your hand</h3>
-          <p>Start free, pick a paid plan, or talk through custom scope so the lead becomes a real contact with a real next step.</p>
+          <p>Start free, pick a paid plan, or use a scoped one-time payment when the work should be a deposit or project checkout.</p>
         </article>
         <article class="pipeline-card">
           <span class="pipeline-step">Step 3</span>

--- a/launch-your-site.html
+++ b/launch-your-site.html
@@ -25,7 +25,7 @@
   <meta name="twitter:title" content="Launch Your Site | 3dvr.tech" />
   <meta
     name="twitter:description"
-    content="Start with $20/month launch help, move into Builder at $50/month, or scope a custom project with 3dvr.tech."
+    content="Start with $20/month launch help, move into Builder at $50/month, or use a custom one-time payment for scoped project work with 3dvr.tech."
   />
   <meta name="twitter:image" content="https://3dvr.tech/3DVR.png" />
 
@@ -622,8 +622,8 @@
             <span>Best fit for active businesses that need a site, updates, follow-up, and ongoing support.</span>
           </li>
           <li>
-            <strong>Custom scope</strong>
-            <span>Use this when you need a larger build, embedded help, or a one-time sprint.</span>
+            <strong>Custom one-time</strong>
+            <span>Use this for scoped project payments, deposits, or one-time sprints.</span>
           </li>
         </ul>
       </div>
@@ -631,7 +631,7 @@
       <aside class="offer-panel" aria-labelledby="offer-title">
         <p class="panel-label">Current focus</p>
         <h2 id="offer-title">A simple offer people can understand and say yes to.</h2>
-        <p>Start with direct help, move into Builder when the business is active, and scope custom work only when the project actually needs it.</p>
+        <p>Start with direct help, move into Builder when the business is active, and use custom one-time payments only when the project actually needs a scoped deposit or checkout.</p>
 
         <div class="price-stack">
           <article class="price-card">
@@ -651,8 +651,8 @@
           <article class="price-card">
             <div class="price-mark">Custom</div>
             <div>
-              <h3>Bigger scope</h3>
-              <p>Use this when you need a more complex build, embedded support, or one-time sprint work.</p>
+              <h3>One-time payment</h3>
+              <p>Use this when the work should be scoped upfront as a project checkout, deposit, or sprint instead of another monthly plan.</p>
             </div>
           </article>
         </div>
@@ -799,7 +799,7 @@
 
         <article class="faq-card">
           <h3>When should I start on Builder or custom?</h3>
-          <p>Start on Builder if the business is active and needs a clearer operating lane. Use custom scope when the project is bigger than a normal monthly support flow.</p>
+          <p>Start on Builder if the business is active and needs a clearer operating lane. Use custom when the work should be a scoped one-time payment or deposit.</p>
         </article>
       </div>
     </section>

--- a/subscribe/founder-plan.html
+++ b/subscribe/founder-plan.html
@@ -195,7 +195,7 @@
         </div>
       </div>
       <div class="cta-block">
-        Need deeper consulting or a custom scope? <a href="../consulting.html">Let’s chat.</a>
+        Need deeper consulting or a custom one-time payment? <a href="../consulting.html">Let’s chat.</a>
       </div>
     </section>
 

--- a/subscribe/index.html
+++ b/subscribe/index.html
@@ -20,7 +20,7 @@
   <meta property="og:title" content="3dvr.tech Memberships" />
   <meta
     property="og:description"
-    content="Compare 3dvr.tech plans for website launches, growth support, deeper builder partnership, and custom project work."
+    content="Compare 3dvr.tech plans for website launches, growth support, deeper builder partnership, and custom one-time payments."
   />
   <meta property="og:url" content="https://3dvr.tech/subscribe/" />
   <meta property="og:image" content="https://3dvr.tech/3DVR.png" />
@@ -29,7 +29,7 @@
   <meta name="twitter:title" content="3dvr.tech Memberships" />
   <meta
     name="twitter:description"
-    content="Compare 3dvr.tech plans for website launches, growth support, deeper builder partnership, and custom project work."
+    content="Compare 3dvr.tech plans for website launches, growth support, deeper builder partnership, and custom one-time payments."
   />
   <meta name="twitter:image" content="https://3dvr.tech/3DVR.png" />
   <script type="application/ld+json">
@@ -330,7 +330,7 @@
         <article class="journey-card">
           <span class="journey-step">Step 1</span>
           <h4>Pick the right lane</h4>
-          <p>Use the plan cards and business-type pages to decide whether this is Free, Founder, Builder, Enterprise, or custom scope.</p>
+          <p>Use the plan cards and business-type pages to decide whether this is Free, Founder, Builder, Enterprise, or a custom one-time payment.</p>
         </article>
         <article class="journey-card">
           <span class="journey-step">Step 2</span>

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -22,7 +22,7 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /Launch in 3 Days/);
     assert.match(html, /Default for businesses/);
     assert.match(html, /Run one calmer team system/);
-    assert.match(html, /Talk through the bigger scope/);
+    assert.match(html, /One-time payment or deposit/);
     assert.match(html, /\$20/);
     assert.match(html, /\$50/);
     assert.match(html, /\$200/);
@@ -115,6 +115,7 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /Pick the right lane/);
     assert.match(html, /Keep one account/);
     assert.match(html, /Start the customer journey/);
+    assert.match(html, /custom one-time payment/);
     assert.match(html, /Open portal start/);
     assert.match(html, /No credit card required\. Create one portal account and start organizing what matters\./);
     assert.match(html, /Start Free in Portal/);
@@ -176,10 +177,13 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /Message me/);
     assert.match(html, /A simple offer people can understand and say yes to\./);
     assert.match(html, /Start with direct help, move into Builder when the business is active/);
+    assert.match(html, /custom one-time payments only when the project actually needs a scoped deposit or checkout/);
     assert.match(html, /Show up clearly fast\./);
     assert.match(html, /reads cleanly on mobile and gives visitors a clear next step\./);
     assert.match(html, /Builder/);
     assert.match(html, /Custom/);
+    assert.match(html, /One-time payment/);
+    assert.match(html, /project checkout, deposit, or sprint instead of another monthly plan/);
     assert.match(html, /mailto:3dvr\.tech@gmail\.com\?subject=3DVR%20Project%20Inquiry/);
     assert.doesNotMatch(html, /Look credible fast\./);
     assert.doesNotMatch(html, /looks credible on mobile/);


### PR DESCRIPTION
## Summary
- Reframes Custom on the homepage and launch page as scoped one-time payments/deposits
- Aligns subscribe metadata and Founder detail copy with one-time payment language
- Updates customer-journey assertions so Custom does not drift back into recurring scope language

## Tests
- PASS: node --test tests/customer-journey.test.js tests/homepage-growth.test.js
- NOTE: npm run test:unit has unrelated existing failures in tests/life-plan.test.js and tests/vercel-insights-tag.test.js