### PR TITLE
[codex] clarify homepage decision path

### DIFF
--- a/3dvr-world/index.html
+++ b/3dvr-world/index.html
@@ -8,6 +8,7 @@
     name="description"
     content="A full-screen 3DVR prototype for a device-safe 3D homepage and world using a framed CSS scene instead of fragile browser-specific 3D stacks."
   />
+  <script defer src="/_vercel/insights/script.js"></script>
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body class="world-body">

--- a/frame-club-test/index.html
+++ b/frame-club-test/index.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Moved to 3DVR World</title>
   <link rel="canonical" href="https://www.3dvr.tech/3dvr-world/" />
+  <script defer src="/_vercel/insights/script.js"></script>
   <script>
     window.location.replace('/3dvr-world/');
   </script>

--- a/index.html
+++ b/index.html
@@ -350,6 +350,35 @@
       gap: 1rem;
       justify-content: center;
     }
+    .hero-route-guide {
+      width: min(100%, 760px);
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0.9rem;
+      padding: 1rem;
+      border-radius: 20px;
+      background: rgba(0, 0, 0, 0.28);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      box-shadow: 0 12px 24px rgba(0, 0, 0, 0.18);
+    }
+    .hero-route {
+      display: grid;
+      gap: 0.35rem;
+      padding: 0.9rem 1rem;
+      border-radius: 16px;
+      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      text-align: left;
+    }
+    .hero-route strong {
+      font-size: 1rem;
+      color: var(--accent);
+    }
+    .hero-route span {
+      font-size: 0.92rem;
+      color: rgba(255, 255, 255, 0.8);
+      line-height: 1.45;
+    }
     .hero-feedback {
       width: min(100%, 760px);
       display: flex;
@@ -1472,6 +1501,17 @@
             For service businesses
           </a>
         </div>
+        <div class="hero-route-guide" aria-label="Choose your first step">
+          <div class="hero-route">
+            <strong>Launch in 3 Days</strong>
+            <span>Best when you need the first live page or offer fast.</span>
+          </div>
+          <div class="hero-route">
+            <strong>Start free in Portal</strong>
+            <span>Best when you want structure first and can pay later.</span>
+          </div>
+        </div>
+        <p class="hero-route-summary">Choose one of three lanes: a daily check-in, a small support group, or direct help launching a project or offer.</p>
         <div class="hero-feedback" aria-label="Homepage clarity feedback">
           <span id="heroFeedbackPrompt" class="hero-feedback__prompt">Does this explain the offer clearly?</span>
           <div class="hero-feedback__buttons">

--- a/install-agent.html
+++ b/install-agent.html
@@ -6,6 +6,7 @@
   <title>Install 3dvr Agent</title>
   <meta name="description" content="Install the 3dvr local agent on Debian, Termux, WSL, or macOS.">
   <link rel="icon" href="/3DVRfavicon.png">
+  <script defer src="/_vercel/insights/script.js"></script>
   <style>
     :root {
       color-scheme: dark;

--- a/nomad-system.html
+++ b/nomad-system.html
@@ -10,6 +10,7 @@
   <meta name="robots" content="index, follow" />
   <link rel="canonical" href="https://3dvr.tech/nomad-system.html" />
   <title>3dvr.tech Nomad System</title>
+  <script defer src="/_vercel/insights/script.js"></script>
   <style>
     :root {
       --bg: #08111f;

--- a/pocket-workstation.html
+++ b/pocket-workstation.html
@@ -8,6 +8,7 @@
     name="description"
     content="Turn your phone into a builder console with the 3dvr Pocket Workstation: notes, commands, projects, and a Termux install flow."
   />
+  <script defer src="/_vercel/insights/script.js"></script>
   <style>
     :root {
       --bg: #08111a;

--- a/subscribe/index.html
+++ b/subscribe/index.html
@@ -178,6 +178,7 @@
       <p class="hero-helper">
         New here? Start with a plan below. Returning? <a data-portal-path="/billing/" href="https://portal.3dvr.tech/billing/" target="_blank" rel="noopener">Open the billing center</a>.
       </p>
+      <p class="hero-helper">Start free to get organized, then move into the portal when you're ready.</p>
       <p class="hero-helper">Use the same portal account for free access, upgrades, invoices, and support.</p>
     </section>
 

--- a/tests/homepage-growth.test.js
+++ b/tests/homepage-growth.test.js
@@ -18,6 +18,9 @@ test('homepage ships Gun-backed experiment and feedback plumbing', async () => {
   assert.match(html, /data-growth-cta="start-free-primary"/);
   assert.match(html, /data-growth-cta="see-plans"/);
   assert.match(html, /data-growth-cta="for-service-businesses"/);
+  assert.match(html, /hero-route-guide/);
+  assert.match(html, /Best when you need the first live page or offer fast\./);
+  assert.match(html, /Best when you want structure first and can pay later\./);
   assert.match(html, /data-growth-cta="plan-free"/);
   assert.match(html, /data-growth-cta="sticky-start-free"[^>]+data-portal-path="\/free-trial\.html"/);
   assert.match(html, /data-growth-cta="start-free-primary"[^>]+data-portal-path="\/free-trial\.html"/);


### PR DESCRIPTION
Make the public homepage easier to understand in the first 5 seconds while keeping the existing launch paths intact.

What changed:
- adds a two-path guide near the hero for Launch in 3 Days vs Start free in Portal
- restores the plain-language three-lane sentence used by the free-plan onboarding copy
- adds Vercel Insights to the HTML pages missing it so the site test suite is consistent again
- keeps the rest of the plan ladder and portal handoff unchanged

Validation:
- node --test tests/homepage-growth.test.js
- node --test tests/customer-journey.test.js
- node --test tests/life-plan.test.js
- node --test tests/vercel-insights-tag.test.js
- node --test tests/*.test.js