### PR TITLE
[codex] Remove quick start hero dock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,10 @@ Keep the marketing site and billing entry points aligned with the portal environ
 - Open a pull request for changes that should be kept, reviewed, or deployed. Treat the PR as the project memory for why the change exists.
 - Use concise PR descriptions that state the user-facing goal, the environment impact, and any billing or portal-link risks.
 - Keep branches and PRs scoped narrowly so they are easy to review and revert if needed.
+- In this Android/Termux-backed environment, GitHub CLI auth may live under `/data/data/com.termux/files/home/.config/gh` even when the active shell is `/root`.
+- If `git push` or `gh` reports missing GitHub credentials, run GitHub commands with `HOME=/data/data/com.termux/files/home`, for example:
+  - `HOME=/data/data/com.termux/files/home git push -u origin <branch>`
+  - `HOME=/data/data/com.termux/files/home /data/data/com.termux/files/usr/bin/gh pr create ...`
 
 ## Deployment Topology
 - Keep `3dvr-web` and `3dvr-portal` on the same branch matrix:

--- a/index.html
+++ b/index.html
@@ -473,56 +473,6 @@
       font-size: 0.82rem;
       color: rgba(255,255,255,0.78);
     }
-    .hero-choice-dock {
-      display: grid;
-      gap: 0.85rem;
-      width: min(100%, 760px);
-    }
-    .hero-choice-dock__label {
-      font-size: 0.82rem;
-      letter-spacing: 0.16em;
-      text-transform: uppercase;
-      color: rgba(255,255,255,0.72);
-    }
-    .hero-choice-dock__grid {
-      display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 0.8rem;
-      width: 100%;
-    }
-    .hero-choice-card {
-      display: grid;
-      gap: 0.35rem;
-      padding: 1.1rem 1.1rem 1.05rem;
-      border-radius: 20px;
-      text-decoration: none;
-      background: linear-gradient(135deg, rgba(255,255,255,0.12), rgba(255,255,255,0.08));
-      border: 1px solid rgba(255,255,255,0.16);
-      color: var(--text-light);
-      text-align: left;
-      transition: transform 0.3s ease, background 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
-      box-shadow: 0 14px 30px rgba(0,0,0,0.22);
-    }
-    .hero-choice-card:hover {
-      transform: translateY(-3px);
-      background: linear-gradient(135deg, rgba(0,255,200,0.18), rgba(255,255,255,0.11));
-      border-color: rgba(0,255,200,0.38);
-      box-shadow: 0 18px 36px rgba(0,0,0,0.28);
-    }
-    .hero-choice-card strong {
-      font-size: 1.02rem;
-      color: var(--accent);
-    }
-    .hero-choice-card span {
-      font-size: 0.88rem;
-      color: rgba(255,255,255,0.8);
-    }
-    .hero-choice-card--launch {
-      background: linear-gradient(135deg, rgba(0,255,200,0.18), rgba(255,255,255,0.08));
-    }
-    .hero-choice-card--free {
-      background: linear-gradient(135deg, rgba(95,39,205,0.18), rgba(255,255,255,0.08));
-    }
     .hero-buyer-dock {
       display: grid;
       gap: 0.85rem;
@@ -760,9 +710,6 @@
         grid-column: 1 / -1;
         justify-self: center;
         width: min(100%, calc(50% - 0.4rem));
-      }
-      .hero-choice-dock__grid {
-        grid-template-columns: 1fr;
       }
       .hero-buyer-dock__grid { grid-template-columns: 1fr; }
       .hero-vision-highlights { text-align: left; }
@@ -1611,19 +1558,6 @@
           <a class="hero-button hero-button--ghost" data-growth-cta="for-service-businesses" href="subscribe/professional-services.html">
             For service businesses
           </a>
-        </div>
-        <div class="hero-choice-dock" aria-label="Quick start choices">
-          <span class="hero-choice-dock__label">Quick start choices</span>
-          <div class="hero-choice-dock__grid">
-            <a
-              class="hero-choice-card hero-choice-card--launch"
-              data-growth-cta="launch-in-3-days"
-              href="launch-in-3-days.html"
-            >
-              <strong>Launch in 3 Days</strong>
-              <span>Best when you need the first live page or offer fast.</span>
-            </a>
-          </div>
         </div>
         <div class="hero-feedback" aria-label="Homepage clarity feedback">
           <span id="heroFeedbackPrompt" class="hero-feedback__prompt">Does this explain the offer clearly?</span>

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -11,9 +11,7 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /Get a site, landing page, or simple business system with direct help from idea to launch\./);
     assert.match(html, /Start Free/);
     assert.match(html, /Start free in portal/);
-    assert.match(html, /Quick start choices/);
     assert.match(html, /Launch in 3 Days/);
-    assert.match(html, /Best when you need the first live page or offer fast\./);
     assert.match(html, /A clear place to land when you need a site, support, or a launch plan\./);
     assert.match(html, /href="3dvr-world\//);
     assert.match(html, /data-portal-path="\/free-trial\.html"/);


### PR DESCRIPTION
Removes the now-redundant Quick start choices dock from the homepage hero, cleans up the unused hero-choice CSS, and keeps the customer journey copy test aligned.\n\nAlso documents the Termux GitHub CLI HOME override in AGENTS.md so future agents can push reliably from this environment.\n\nValidation: node --test tests/customer-journey.test.js