### PR TITLE
[codex] Remove service businesses hero button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1555,9 +1555,6 @@
           <a class="hero-button hero-button--ghost" data-growth-cta="see-plans" href="#subscribe">
             See plans
           </a>
-          <a class="hero-button hero-button--ghost" data-growth-cta="for-service-businesses" href="subscribe/professional-services.html">
-            For service businesses
-          </a>
         </div>
         <div class="hero-feedback" aria-label="Homepage clarity feedback">
           <span id="heroFeedbackPrompt" class="hero-feedback__prompt">Does this explain the offer clearly?</span>

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -70,7 +70,6 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /Trusted by friends, family, and small businesses/);
     assert.match(html, /See plans and services/);
     assert.match(html, /See plans/);
-    assert.match(html, /For service businesses/);
     assert.match(html, /hero-logo-card/);
     assert.match(html, /Browser experiments \/ 3DVR world prototype/);
     assert.doesNotMatch(html, /Open the full-screen 3DVR world prototype/);

--- a/tests/homepage-growth.test.js
+++ b/tests/homepage-growth.test.js
@@ -17,7 +17,6 @@ test('homepage ships Gun-backed experiment and feedback plumbing', async () => {
   assert.match(html, /data-growth-cta="sticky-start-free"/);
   assert.match(html, /data-growth-cta="start-free-primary"/);
   assert.match(html, /data-growth-cta="see-plans"/);
-  assert.match(html, /data-growth-cta="for-service-businesses"/);
   assert.match(html, /class="hero-logo-card"/);
   assert.match(html, /A clear place to land when you need a site, support, or a launch plan\./);
   assert.doesNotMatch(html, /data-growth-cta="enter-3dvr-world"/);


### PR DESCRIPTION
Removes the For service businesses button from the homepage hero and updates the homepage copy/growth tests.\n\nValidation: node --test tests/customer-journey.test.js tests/homepage-growth.test.js