### PR TITLE
[codex] Add starter lane to homepage plans

### DIFF
--- a/index.html
+++ b/index.html
@@ -443,7 +443,7 @@
     }
     .hero-plan-dock__grid {
       display: grid;
-      grid-template-columns: repeat(5, minmax(0, 1fr));
+      grid-template-columns: repeat(6, minmax(0, 1fr));
       gap: 0.8rem;
       width: 100%;
     }
@@ -1419,6 +1419,15 @@
             >
               <strong>Free</strong>
               <span>Get organized first</span>
+            </a>
+            <a
+              class="hero-plan-chip"
+              data-growth-cta="plan-starter"
+              data-portal-path="/billing/?plan=starter"
+              href="https://portal.3dvr.tech/billing/?plan=starter"
+            >
+              <strong>$5</strong>
+              <span>Light monthly support</span>
             </a>
             <a
               class="hero-plan-chip"

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -14,15 +14,18 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /Launch in 3 Days/);
     assert.match(html, /A clear place to land when you need a site, support, or a launch plan\./);
     assert.match(html, /data-portal-path="\/free-trial\.html"/);
+    assert.match(html, /data-portal-path="\/billing\/\?plan=starter"/);
     assert.match(html, /data-portal-path="\/billing\/\?plan=pro"/);
     assert.match(html, /data-portal-path="\/billing\/\?plan=builder"/);
     assert.match(html, /data-portal-path="\/billing\/\?plan=embedded"/);
     assert.match(html, /Pick the lane that fits\./);
     assert.match(html, /Get organized first/);
+    assert.match(html, /Light monthly support/);
     assert.match(html, /Launch in 3 Days/);
     assert.match(html, /Default for businesses/);
     assert.match(html, /Run one calmer team system/);
     assert.match(html, /One-time payment or deposit/);
+    assert.match(html, /\$5/);
     assert.match(html, /\$20/);
     assert.match(html, /\$50/);
     assert.match(html, /\$200/);

--- a/tests/homepage-growth.test.js
+++ b/tests/homepage-growth.test.js
@@ -21,9 +21,11 @@ test('homepage ships Gun-backed experiment and feedback plumbing', async () => {
   assert.match(html, /A clear place to land when you need a site, support, or a launch plan\./);
   assert.doesNotMatch(html, /data-growth-cta="enter-3dvr-world"/);
   assert.match(html, /data-growth-cta="plan-free"/);
+  assert.match(html, /data-growth-cta="plan-starter"/);
   assert.match(html, /data-growth-cta="sticky-start-free"[^>]+data-portal-path="\/free-trial\.html"/);
   assert.match(html, /data-growth-cta="start-free-primary"[^>]+data-portal-path="\/free-trial\.html"/);
   assert.match(html, /data-growth-cta="plan-free"[^>]+data-portal-path="\/free-trial\.html"/);
+  assert.match(html, /data-growth-cta="plan-starter"[^>]+data-portal-path="\/billing\/\?plan=starter"/);
   assert.match(html, /data-growth-cta="plan-20"[^>]+data-portal-path="\/billing\/\?plan=pro"/);
   assert.match(html, /data-growth-cta="plan-50"[^>]+data-portal-path="\/billing\/\?plan=builder"/);
   assert.match(html, /data-growth-cta="plan-200"[^>]+data-portal-path="\/billing\/\?plan=embedded"/);
@@ -37,6 +39,7 @@ test('homepage ships Gun-backed experiment and feedback plumbing', async () => {
   assert.doesNotMatch(html, /data-growth-cta="sticky-start-free"[^>]+href="subscribe\/free-plan\.html"/);
   assert.doesNotMatch(html, /data-growth-cta="start-free-primary"[^>]+href="subscribe\/free-plan\.html"/);
   assert.doesNotMatch(html, /data-growth-cta="plan-free"[^>]+href="subscribe\/free-plan\.html"/);
+  assert.doesNotMatch(html, /data-growth-cta="plan-starter"[^>]+href="subscribe\/family-friends\.html"/);
   assert.doesNotMatch(html, /data-growth-cta="plan-20"[^>]+href="subscribe\/founder-plan\.html"/);
   assert.doesNotMatch(html, /data-growth-cta="plan-50"[^>]+href="subscribe\/builder-plan\.html"/);
   assert.doesNotMatch(html, /data-growth-cta="plan-200"[^>]+href="subscribe\/support-teams\.html"/);

--- a/tests/playwright/homepage-mobile.spec.js
+++ b/tests/playwright/homepage-mobile.spec.js
@@ -32,7 +32,7 @@ test.describe('homepage mobile sticky CTA', () => {
     await expect(stickyCta).toBeVisible();
   });
 
-  test('centers the final hero plan chip when the mobile plan row count is odd', async ({ page }, testInfo) => {
+  test('keeps hero plan chips inside the mobile grid', async ({ page }, testInfo) => {
     test.skip(!isMobileProject(testInfo), 'Mobile-only homepage check');
 
     await page.goto('/');
@@ -46,20 +46,23 @@ test.describe('homepage mobile sticky CTA', () => {
       }
 
       const gridRect = grid.getBoundingClientRect();
-      const lastRect = chips.at(-1).getBoundingClientRect();
+      const chipRects = chips.map((chip) => chip.getBoundingClientRect());
 
       return {
         chipCount: chips.length,
-        gridCenter: Math.round(gridRect.left + (gridRect.width / 2)),
-        lastCenter: Math.round(lastRect.left + (lastRect.width / 2)),
-        lastWidth: Math.round(lastRect.width),
+        gridLeft: Math.round(gridRect.left),
+        gridRight: Math.round(gridRect.right),
         gridWidth: Math.round(gridRect.width),
+        minChipLeft: Math.round(Math.min(...chipRects.map((rect) => rect.left))),
+        maxChipRight: Math.round(Math.max(...chipRects.map((rect) => rect.right))),
+        maxChipWidth: Math.round(Math.max(...chipRects.map((rect) => rect.width))),
       };
     });
 
     expect(layout).not.toBeNull();
-    expect(layout.chipCount % 2).toBe(1);
-    expect(layout.lastWidth).toBeLessThan(layout.gridWidth);
-    expect(Math.abs(layout.lastCenter - layout.gridCenter)).toBeLessThanOrEqual(2);
+    expect(layout.chipCount).toBeGreaterThan(0);
+    expect(layout.minChipLeft).toBeGreaterThanOrEqual(layout.gridLeft - 1);
+    expect(layout.maxChipRight).toBeLessThanOrEqual(layout.gridRight + 1);
+    expect(layout.maxChipWidth).toBeLessThan(layout.gridWidth);
   });
 });


### PR DESCRIPTION
Adds the  Family & Friends / starter lane to the homepage plan dock under 'Pick the lane that fits.' It links directly to the portal billing starter plan and updates copy/growth/mobile layout tests for the six-chip plan grid.\n\nValidation:\n- node --test tests/customer-journey.test.js tests/homepage-growth.test.js\n- npx playwright test tests/playwright/homepage-mobile.spec.js --project=chromium-fold-closed