### PR TITLE
[codex] Simplify subscribe section copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -679,6 +679,36 @@
       max-width: 1400px; padding: 0 1rem; margin-top: 2rem;
     }
     .card-grid { align-items: stretch; }
+    .subscribe-guide {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+      gap: 0.85rem;
+      width: min(100%, 820px);
+      list-style: none;
+      margin: 0.5rem auto 0;
+      padding: 0;
+      text-align: left;
+    }
+    .subscribe-guide li {
+      display: grid;
+      gap: 0.25rem;
+      padding: 0.2rem 0 0.2rem 1rem;
+      border-left: 3px solid rgba(255, 255, 255, 0.62);
+    }
+    .subscribe-guide strong {
+      color: white;
+      font-size: 1rem;
+    }
+    .subscribe-guide span {
+      color: rgba(255, 255, 255, 0.86);
+      font-size: 0.96rem;
+      line-height: 1.45;
+    }
+    .subscribe-note {
+      color: rgba(255, 255, 255, 0.88);
+      font-size: clamp(1rem, 1.5vw, 1.12rem);
+      margin: 1.5rem 0 0;
+    }
     .card {
       flex: 1 1 calc(20% - 2rem);
       min-width: 220px; max-width: 260px;
@@ -1563,7 +1593,21 @@
 
   <section id="subscribe" style="background: var(--bg-subscribe);">
     <h2>Simple ways to work together</h2>
-    <p>Start free if you need structure. Use Launch in 3 Days at $20/month for the first page or offer. If you already have real customers, quotes, follow-up, or weekly operations to manage, Builder at $50/month is the default business lane. Tap a card to continue in portal.</p>
+    <ul class="subscribe-guide" aria-label="Plan fit guide">
+      <li>
+        <strong>Start free</strong>
+        <span>Get structure first.</span>
+      </li>
+      <li>
+        <strong>$20/month</strong>
+        <span>Launch the first page or offer.</span>
+      </li>
+      <li>
+        <strong>$50/month</strong>
+        <span>Default for active businesses.</span>
+      </li>
+    </ul>
+    <p class="subscribe-note">Tap a card to continue in portal.</p>
     <div class="card-grid">
       <a
         class="card"

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -43,7 +43,10 @@ describe('3dvr-web customer journey copy', () => {
     assert.doesNotMatch(html, /Join a Cell/);
     assert.doesNotMatch(html, /Life starter/);
     assert.match(html, /Simple ways to work together/);
-    assert.match(html, /Start free if you need structure\. Use Launch in 3 Days at \$20\/month for the first page or offer\./);
+    assert.match(html, /Plan fit guide/);
+    assert.match(html, /Get structure first\./);
+    assert.match(html, /Launch the first page or offer\./);
+    assert.match(html, /Default for active businesses\./);
     assert.match(html, /Tap a card to continue in portal\./);
     assert.match(html, /Use this for Launch in 3 Days when the offer, site, or first page still needs to become real\./);
     assert.match(html, /Default for active businesses that need a site, follow-up, updates, and calmer operations\./);


### PR DESCRIPTION
## Summary
- Replace the dense subscribe intro paragraph with a short plan-fit guide
- Keep the portal handoff instruction as a separate note
- Update homepage copy tests for the shorter guidance

## Tests
- node --test tests/customer-journey.test.js tests/homepage-growth.test.js