### PR TITLE
[codex] Simplify founder plan copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -1589,7 +1589,7 @@
         href="https://portal.3dvr.tech/billing/?plan=pro"
       >
         <h3><span class="plan-name">Founder Plan</span><br><span class="plan-price">$20 monthly</span></h3>
-        <p>Use this for Launch in 3 Days when the offer, site, or first page still needs to become real.</p>
+        <p>For launching your product, brand, or first offer when it needs to become real now.</p>
         <span class="btn-like">Continue in Portal</span>
       </a>
       <a

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -51,7 +51,8 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /Family &amp; Friends/);
     assert.match(html, /\$5 monthly/);
     assert.match(html, /Light monthly support for people close to the work who want to help keep 3dvr moving\./);
-    assert.match(html, /Use this for Launch in 3 Days when the offer, site, or first page still needs to become real\./);
+    assert.match(html, /For launching your product, brand, or first offer when it needs to become real now\./);
+    assert.doesNotMatch(html, /Use this for Launch in 3 Days when the offer, site, or first page still needs to become real\./);
     assert.match(html, /Default for active businesses that need a site, follow-up, updates, and calmer operations\./);
     assert.match(html, /Pair it with a setup sprint when you want the first workflow built faster\./);
     assert.match(html, /Best for support teams, organizations, and shared workflows that need one calmer operating lane\./);


### PR DESCRIPTION
## Summary
- Simplify the homepage Founder Plan card so it stands alone for new visitors
- Keep the become-real phrasing without referencing Launch in 3 Days
- Update homepage copy tests

## Tests
- node --test tests/customer-journey.test.js tests/homepage-growth.test.js