### PR TITLE
[codex] Tighten founder plan copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -1589,7 +1589,7 @@
         href="https://portal.3dvr.tech/billing/?plan=pro"
       >
         <h3><span class="plan-name">Founder Plan</span><br><span class="plan-price">$20 monthly</span></h3>
-        <p>For launching your product, brand, or first offer when it needs to become real now.</p>
+        <p>For launching your product, brand, or first offer immediately.</p>
         <span class="btn-like">Continue in Portal</span>
       </a>
       <a

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -51,7 +51,8 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /Family &amp; Friends/);
     assert.match(html, /\$5 monthly/);
     assert.match(html, /Light monthly support for people close to the work who want to help keep 3dvr moving\./);
-    assert.match(html, /For launching your product, brand, or first offer when it needs to become real now\./);
+    assert.match(html, /For launching your product, brand, or first offer immediately\./);
+    assert.doesNotMatch(html, /when it needs to become real now/);
     assert.doesNotMatch(html, /Use this for Launch in 3 Days when the offer, site, or first page still needs to become real\./);
     assert.match(html, /Default for active businesses that need a site, follow-up, updates, and calmer operations\./);
     assert.match(html, /Pair it with a setup sprint when you want the first workflow built faster\./);


### PR DESCRIPTION
## Summary
- Shorten the Founder Plan homepage card copy
- Remove the become-real phrasing from that card
- Update homepage copy tests

## Tests
- node --test tests/customer-journey.test.js tests/homepage-growth.test.js