### PR TITLE
[codex] Remove launch card from homepage plans

### DIFF
--- a/index.html
+++ b/index.html
@@ -1610,11 +1610,6 @@
         <p>Best for support teams, organizations, and shared workflows that need one calmer operating lane.</p>
         <span class="btn-like">Continue in Portal</span>
       </a>
-      <a href="launch-in-3-days.html" class="card" data-growth-cta="launch-in-3-days">
-        <h3><span class="plan-name">Launch in 3 Days</span><br><span class="plan-price">$20 starting point</span></h3>
-        <p>Use this if you want the clearest path from rough idea to a live page fast, then move into Builder if the business lane grows.</p>
-        <span class="btn-like">See the launch flow</span>
-      </a>
     </div>
   </section>
 

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -57,10 +57,8 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /Default for active businesses that need a site, follow-up, updates, and calmer operations\./);
     assert.match(html, /Pair it with a setup sprint when you want the first workflow built faster\./);
     assert.match(html, /Best for support teams, organizations, and shared workflows that need one calmer operating lane\./);
-    assert.match(html, /Launch in 3 Days/);
-    assert.match(html, /\$20 starting point/);
-    assert.match(html, /See the launch flow/);
-    assert.match(html, /href="launch-in-3-days\.html"/);
+    assert.doesNotMatch(html, /\$20 starting point/);
+    assert.doesNotMatch(html, /See the launch flow/);
     assert.match(html, /A clear place to land when you need a site, support, or a launch plan\./);
     assert.doesNotMatch(html, /Websites\. Apps\. Real support\./);
     assert.doesNotMatch(html, /A real place to land when you need a site, support, or a launch plan\./);

--- a/tests/homepage-growth.test.js
+++ b/tests/homepage-growth.test.js
@@ -30,8 +30,7 @@ test('homepage ships Gun-backed experiment and feedback plumbing', async () => {
   assert.match(html, /data-growth-cta="plan-50"[^>]+data-portal-path="\/billing\/\?plan=builder"/);
   assert.match(html, /data-growth-cta="plan-200"[^>]+data-portal-path="\/billing\/\?plan=embedded"/);
   assert.match(html, /data-growth-cta="plan-custom"/);
-  assert.match(html, /data-growth-cta="launch-in-3-days"/);
-  assert.match(html, /href="launch-in-3-days\.html"[^>]+data-growth-cta="launch-in-3-days"/);
+  assert.doesNotMatch(html, /data-growth-cta="launch-in-3-days"/);
   assert.match(html, /href="nomad-system\.html"[^>]+data-growth-cta="explore-nomad-system"/);
   assert.match(html, /data-portal-path="\/billing\/\?plan=custom"/);
   assert.match(html, /href="https:\/\/portal\.3dvr\.tech\/billing\/\?plan=custom"/);


### PR DESCRIPTION
## Summary
- Remove the standalone Launch in 3 Days card from the homepage subscribe grid
- Keep Founder Plan as the 0 launch-focused option
- Update homepage tests for the smaller card set

## Tests
- node --test tests/customer-journey.test.js tests/homepage-growth.test.js