### PR TITLE
[codex] Update homepage plan button labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -1571,7 +1571,7 @@
       >
         <h3><span class="plan-name">Free Plan</span><br><span class="plan-price">Free!</span></h3>
         <p>Get organized, sort out your next step, and enter the portal without paying first.</p>
-        <span class="btn-like">Start in Portal</span>
+        <span class="btn-like">Start Free</span>
       </a>
       <a
         class="card"
@@ -1581,7 +1581,7 @@
       >
         <h3><span class="plan-name">Family &amp; Friends</span><br><span class="plan-price">$5 monthly</span></h3>
         <p>Light monthly support for people close to the work who want to help keep 3dvr moving.</p>
-        <span class="btn-like">Continue in Portal</span>
+        <span class="btn-like">Choose Plan</span>
       </a>
       <a
         class="card"
@@ -1590,7 +1590,7 @@
       >
         <h3><span class="plan-name">Founder Plan</span><br><span class="plan-price">$20 monthly</span></h3>
         <p>For launching your product, brand, or first offer immediately.</p>
-        <span class="btn-like">Continue in Portal</span>
+        <span class="btn-like">Choose Plan</span>
       </a>
       <a
         class="card"
@@ -1599,7 +1599,7 @@
       >
         <h3><span class="plan-name">Builder Plan</span><br><span class="plan-price">$50 monthly</span></h3>
         <p>Default for active businesses that need a site, follow-up, updates, and calmer operations. Pair it with a setup sprint when you want the first workflow built faster.</p>
-        <span class="btn-like">Continue in Portal</span>
+        <span class="btn-like">Choose Plan</span>
       </a>
       <a
         class="card"
@@ -1608,7 +1608,7 @@
       >
         <h3><span class="plan-name">Enterprise Plan</span><br><span class="plan-price">$200 monthly</span></h3>
         <p>Best for support teams, organizations, and shared workflows that need one calmer operating lane.</p>
-        <span class="btn-like">Continue in Portal</span>
+        <span class="btn-like">Choose Plan</span>
       </a>
     </div>
   </section>

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -52,6 +52,9 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /\$5 monthly/);
     assert.match(html, /Light monthly support for people close to the work who want to help keep 3dvr moving\./);
     assert.match(html, /For launching your product, brand, or first offer immediately\./);
+    assert.match(html, /Choose Plan/);
+    assert.doesNotMatch(html, /Start in Portal/);
+    assert.doesNotMatch(html, /Continue in Portal/);
     assert.doesNotMatch(html, /when it needs to become real now/);
     assert.doesNotMatch(html, /Use this for Launch in 3 Days when the offer, site, or first page still needs to become real\./);
     assert.match(html, /Default for active businesses that need a site, follow-up, updates, and calmer operations\./);


### PR DESCRIPTION
## Summary
- Change the homepage free plan card button to Start Free
- Change paid plan card buttons to Choose Plan
- Add tests to keep portal-facing button text out of the homepage cards

## Tests
- node --test tests/customer-journey.test.js tests/homepage-growth.test.js