### PR TITLE
[codex] Set hero plan grid to three columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -443,7 +443,7 @@
     }
     .hero-plan-dock__grid {
       display: grid;
-      grid-template-columns: repeat(6, minmax(0, 1fr));
+      grid-template-columns: repeat(3, minmax(0, 1fr));
       gap: 0.8rem;
       width: 100%;
     }

--- a/tests/homepage-growth.test.js
+++ b/tests/homepage-growth.test.js
@@ -22,6 +22,7 @@ test('homepage ships Gun-backed experiment and feedback plumbing', async () => {
   assert.doesNotMatch(html, /data-growth-cta="enter-3dvr-world"/);
   assert.match(html, /data-growth-cta="plan-free"/);
   assert.match(html, /data-growth-cta="plan-starter"/);
+  assert.match(html, /grid-template-columns:\s*repeat\(3,\s*minmax\(0,\s*1fr\)\)/);
   assert.match(html, /data-growth-cta="sticky-start-free"[^>]+data-portal-path="\/free-trial\.html"/);
   assert.match(html, /data-growth-cta="start-free-primary"[^>]+data-portal-path="\/free-trial\.html"/);
   assert.match(html, /data-growth-cta="plan-free"[^>]+data-portal-path="\/free-trial\.html"/);


### PR DESCRIPTION
## Summary
- Change the hero plan lane grid from six desktop columns to three
- Keep the mobile two-column override in place
- Add a homepage test assertion for the three-column layout

## Tests
- node --test tests/customer-journey.test.js tests/homepage-growth.test.js
- npm ci
- npx playwright test tests/playwright/homepage-mobile.spec.js --project=chromium-fold-closed