### PR TITLE
Add branded web startup logo

### DIFF
--- a/assets/logo-3dvr.svg
+++ b/assets/logo-3dvr.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">3dvr.tech logo</title>
+  <desc id="desc">A bright 3dvr mark for the main website.</desc>
+  <defs>
+    <linearGradient id="web-bg" x1="70" x2="442" y1="72" y2="438" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0f766e"/>
+      <stop offset="0.45" stop-color="#2563eb"/>
+      <stop offset="1" stop-color="#f97316"/>
+    </linearGradient>
+    <linearGradient id="web-ring" x1="136" x2="376" y1="118" y2="394" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="0.5" stop-color="#99f6e4"/>
+      <stop offset="1" stop-color="#fed7aa"/>
+    </linearGradient>
+    <filter id="depth" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#0f172a" flood-opacity="0.34"/>
+    </filter>
+  </defs>
+  <rect width="512" height="512" rx="104" fill="#07131f"/>
+  <path d="M98 152 256 64l158 88v208l-158 88-158-88V152Z" fill="url(#web-bg)" filter="url(#depth)"/>
+  <path d="M164 188 256 137l92 51v136l-92 51-92-51V188Z" fill="none" stroke="url(#web-ring)" stroke-width="18" stroke-linejoin="round"/>
+  <path d="M256 137v238M164 188l184 136M348 188 164 324" stroke="#f8fafc" stroke-width="12" stroke-linecap="round" opacity="0.5"/>
+  <text x="256" y="271" text-anchor="middle" font-family="Poppins, Inter, Arial, sans-serif" font-size="82" font-weight="900" fill="#ffffff" letter-spacing="-6">3D</text>
+  <text x="256" y="326" text-anchor="middle" font-family="Poppins, Inter, Arial, sans-serif" font-size="46" font-weight="800" fill="#ccfbf1" letter-spacing="5">VR</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,8 @@
   <meta name="robots" content="index, follow" />
   <link rel="canonical" href="https://3dvr.tech/" />
   <title>3dvr.tech</title>
-  <link rel="icon" href="3DVRfavicon.png" />
+  <link rel="icon" type="image/svg+xml" href="/assets/logo-3dvr.svg" />
+  <link rel="alternate icon" href="3DVRfavicon.png" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Poppins:wght@500;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"/>
 
@@ -36,6 +37,11 @@
   />
   <meta name="twitter:image" content="https://3dvr.tech/3DVR.png" />
   <script defer src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script>
+    const hideHomeBoot = () => document.documentElement.classList.add('app-ready');
+    window.addEventListener('load', hideHomeBoot, { once: true });
+    window.setTimeout(hideHomeBoot, 3600);
+  </script>
 
   <script type="application/ld+json">
     {
@@ -125,6 +131,14 @@
         rotate(calc(var(--hero-tilt-x, 0) * 0.06deg));
       transition: transform 120ms ease;
       will-change: transform;
+    }
+
+    .site-logo {
+      display: block;
+      width: 52px;
+      height: 52px;
+      border-radius: 14px;
+      box-shadow: 0 12px 28px rgba(0, 0, 0, 0.22);
     }
 
     nav {
@@ -220,6 +234,75 @@
       box-shadow: 0 0 15px rgba(0,255,200,0.5);
       z-index: 900;
       transition: bottom 0.25s ease, opacity 0.2s ease, transform 0.2s ease;
+    }
+
+    .app-boot {
+      position: fixed;
+      inset: 0;
+      z-index: 2000;
+      display: grid;
+      place-items: center;
+      gap: 1rem;
+      align-content: center;
+      padding: 2rem;
+      background:
+        radial-gradient(circle at 50% 36%, rgba(0, 255, 200, 0.25), transparent 30rem),
+        #07131f;
+      color: #fff;
+      transition: opacity 280ms ease, visibility 280ms ease;
+    }
+
+    .app-ready .app-boot {
+      opacity: 0;
+      visibility: hidden;
+      pointer-events: none;
+    }
+
+    .app-boot__mark {
+      width: 112px;
+      aspect-ratio: 1;
+      border-radius: 28px;
+      box-shadow: 0 28px 80px rgba(0, 0, 0, 0.38);
+      animation: web-boot-float 1600ms ease-in-out infinite;
+    }
+
+    .app-boot__mark img {
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
+
+    .app-boot__text {
+      display: grid;
+      gap: 0.25rem;
+      text-align: center;
+    }
+
+    .app-boot__text strong {
+      font-size: 1.2rem;
+      letter-spacing: 0.02em;
+    }
+
+    .app-boot__text span {
+      color: #ccfbf1;
+      font-size: 0.95rem;
+    }
+
+    .app-boot__bar {
+      width: min(220px, 60vw);
+      height: 4px;
+      overflow: hidden;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.2);
+    }
+
+    .app-boot__bar span {
+      display: block;
+      width: 42%;
+      height: 100%;
+      border-radius: inherit;
+      background: linear-gradient(90deg, #00ffc8, #fed7aa);
+      animation: web-boot-load 1400ms ease-in-out infinite;
     }
 
     @media (max-width: 640px) {
@@ -1324,14 +1407,39 @@
 
     @keyframes fadeSlideIn { to { opacity: 1; transform: translateY(0); } }
     @keyframes fadeIn { to { opacity: 1; } }
+    @keyframes web-boot-float {
+      0%, 100% { transform: translateY(0) scale(1); }
+      50% { transform: translateY(-8px) scale(1.02); }
+    }
+    @keyframes web-boot-load {
+      0% { transform: translateX(-100%); }
+      100% { transform: translateX(240%); }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .app-boot__mark,
+      .app-boot__bar span {
+        animation: none;
+      }
+    }
   </style>
 
   <script defer src="/_vercel/insights/script.js"></script>
   <script defer src="growth/homepage-experiment.js"></script>
 </head>
 <body id="top">
+  <div class="app-boot" aria-hidden="true">
+    <div class="app-boot__mark">
+      <img src="/assets/logo-3dvr.svg" alt="">
+    </div>
+    <div class="app-boot__text">
+      <strong>3dvr.tech</strong>
+      <span>Loading the launch desk</span>
+    </div>
+    <div class="app-boot__bar"><span></span></div>
+  </div>
   <header>
-    <a href="#top"><img src="3DVR.png" alt="3dvr.tech logo" /></a>
+    <a href="#top"><img class="site-logo" src="/assets/logo-3dvr.svg" alt="3dvr.tech logo" /></a>
 
     <!-- a11y & control bindings for mobile menu -->
     <div
@@ -1372,7 +1480,7 @@
         <div class="hero-logo-card">
           <div class="hero-spark hero-spark--top"></div>
           <div class="hero-spark hero-spark--bottom"></div>
-          <img src="3DVR.png" alt="" />
+          <img src="/assets/logo-3dvr.svg" alt="" />
           <p>
             A clear place to land when you need a site, support, or a launch plan.
           </p>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -9,6 +9,12 @@
   "description": "3dvr.tech community-first websites, apps, and digital strategy.",
   "icons": [
     {
+      "src": "/assets/logo-3dvr.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    },
+    {
       "src": "/3DVR.png",
       "sizes": "512x512",
       "type": "image/png"

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,8 @@
-const CACHE_NAME = '3dvr-cache-v3';
+const CACHE_NAME = '3dvr-cache-v4';
 const OFFLINE_ASSETS = [
   '/',
   '/index.html',
+  '/assets/logo-3dvr.svg',
   '/3DVR.png',
   '/3DVRfavicon.png'
 ];

--- a/tests/service-worker.test.js
+++ b/tests/service-worker.test.js
@@ -3,8 +3,10 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import test from 'node:test';
 import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
 
-const serviceWorkerPath = '/data/data/com.termux/files/home/3dvr-web/service-worker.js';
+const serviceWorkerPath = new URL('../service-worker.js', import.meta.url);
+const serviceWorkerFilename = fileURLToPath(serviceWorkerPath);
 
 async function loadServiceWorker({
   cacheMatch,
@@ -55,7 +57,7 @@ async function loadServiceWorker({
   };
 
   vm.runInNewContext(source, sandbox, {
-    filename: path.basename(serviceWorkerPath)
+    filename: path.basename(serviceWorkerFilename)
   });
 
   return { listeners, cachePuts };
@@ -192,4 +194,28 @@ test('service worker keeps same-origin image assets cache-first', async () => {
 
   assert.equal(fetchCalls, 0);
   assert.equal(await response.text(), 'cached-image');
+});
+
+test('service worker keeps the svg app logo cache-first', async () => {
+  let fetchCalls = 0;
+  const { listeners } = await loadServiceWorker({
+    cacheMatch: async (request) => {
+      if (request?.url === 'https://www.3dvr.tech/assets/logo-3dvr.svg') {
+        return new Response('cached-logo', { status: 200 });
+      }
+      return undefined;
+    },
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      return new Response('network-logo', { status: 200 });
+    }
+  });
+
+  const response = await dispatchFetch(
+    listeners,
+    createRequest('https://www.3dvr.tech/assets/logo-3dvr.svg')
+  );
+
+  assert.equal(fetchCalls, 0);
+  assert.equal(await response.text(), 'cached-logo');
 });


### PR DESCRIPTION
## Summary\n- add a lightweight SVG 3dvr.tech app logo\n- use it for the favicon, header logo, hero logo, manifest, and startup screen\n- include the SVG in the service worker cache and make the service worker test path repo-relative\n\n## Tests\n- node --test tests/service-worker.test.js\n- git diff --check\n- local static asset check for /assets/logo-3dvr.svg