### PR TITLE
Brand web logo as 3dvr.tech

### DIFF
--- a/assets/logo-3dvr.svg
+++ b/assets/logo-3dvr.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
   <title id="title">3dvr.tech logo</title>
-  <desc id="desc">A bright 3dvr mark for the main website.</desc>
+  <desc id="desc">A bright 3dvr.tech mark for the main website.</desc>
   <defs>
     <linearGradient id="web-bg" x1="70" x2="442" y1="72" y2="438" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#0f766e"/>
@@ -20,6 +20,6 @@
   <path d="M98 152 256 64l158 88v208l-158 88-158-88V152Z" fill="url(#web-bg)" filter="url(#depth)"/>
   <path d="M164 188 256 137l92 51v136l-92 51-92-51V188Z" fill="none" stroke="url(#web-ring)" stroke-width="18" stroke-linejoin="round"/>
   <path d="M256 137v238M164 188l184 136M348 188 164 324" stroke="#f8fafc" stroke-width="12" stroke-linecap="round" opacity="0.5"/>
-  <text x="256" y="271" text-anchor="middle" font-family="Poppins, Inter, Arial, sans-serif" font-size="82" font-weight="900" fill="#ffffff" letter-spacing="-6">3D</text>
-  <text x="256" y="326" text-anchor="middle" font-family="Poppins, Inter, Arial, sans-serif" font-size="46" font-weight="800" fill="#ccfbf1" letter-spacing="5">VR</text>
+  <text x="256" y="274" text-anchor="middle" font-family="Poppins, Inter, Arial, sans-serif" font-size="76" font-weight="900" fill="#ffffff" letter-spacing="-3">3dvr</text>
+  <text x="256" y="324" text-anchor="middle" font-family="Poppins, Inter, Arial, sans-serif" font-size="42" font-weight="800" fill="#ccfbf1" letter-spacing="1">.tech</text>
 </svg>

--- a/tests/logo-branding.test.js
+++ b/tests/logo-branding.test.js
@@ -1,0 +1,15 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+describe('3dvr-web logo branding', () => {
+  it('brands the SVG app logo as 3dvr.tech', async () => {
+    const logo = await readFile(new URL('../assets/logo-3dvr.svg', import.meta.url), 'utf8');
+    const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+
+    assert.match(logo, /3dvr\.tech logo/);
+    assert.match(logo, />3dvr</);
+    assert.match(logo, />\.tech</);
+    assert.match(html, /<strong>3dvr\.tech<\/strong>/);
+  });
+});


### PR DESCRIPTION
## Summary
- updates the web SVG app logo to read `3dvr.tech` instead of the generic `3D / VR` split
- adds a focused branding regression test for the SVG and boot label

## Tests
- `node --test tests/logo-branding.test.js`
- `git diff --check`
- parsed `assets/logo-3dvr.svg` as XML