### PR TITLE
Add interactive 3D homepage logo token

### DIFF
--- a/homepage-logo-token.js
+++ b/homepage-logo-token.js
@@ -1,0 +1,397 @@
+(function () {
+  const THREE_CDN_URL = 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js';
+  const root = document.querySelector('[data-3dvr-token]');
+  const canvas = document.querySelector('[data-3dvr-token-canvas]');
+
+  if (!root || !canvas) return;
+
+  const state = {
+    dragging: false,
+    lastX: 0,
+    lastY: 0,
+    targetX: -0.2,
+    targetY: 0.38,
+    targetZ: -0.08,
+    currentX: -0.2,
+    currentY: 0.38,
+    currentZ: -0.08,
+    restX: -0.2,
+    restY: 0.38,
+    restZ: -0.08,
+    renderer: null,
+    fallbackContext: null,
+    camera: null,
+    scene: null,
+    token: null,
+    frame: 0,
+    interactionsReady: false,
+    dragIdleTimer: 0
+  };
+
+  function loadThree() {
+    if (window.THREE) return Promise.resolve(window.THREE);
+
+    return new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = THREE_CDN_URL;
+      script.async = true;
+      script.onload = () => resolve(window.THREE);
+      script.onerror = () => reject(new Error('Unable to load Three.js.'));
+      document.head.appendChild(script);
+    });
+  }
+
+  function makeFaceTexture(THREE, mirrored) {
+    const textureCanvas = document.createElement('canvas');
+    const size = 1024;
+    textureCanvas.width = size;
+    textureCanvas.height = size;
+    const context = textureCanvas.getContext('2d');
+    const gradient = context.createRadialGradient(size * 0.35, size * 0.25, 80, size * 0.5, size * 0.5, size * 0.58);
+    gradient.addColorStop(0, '#45ffe3');
+    gradient.addColorStop(0.46, '#1768f2');
+    gradient.addColorStop(1, '#07131f');
+
+    context.fillStyle = gradient;
+    context.fillRect(0, 0, size, size);
+
+    context.save();
+    context.translate(size / 2, size / 2);
+    context.rotate(Math.PI / 4);
+    context.strokeStyle = 'rgba(255, 255, 255, 0.18)';
+    context.lineWidth = 28;
+    for (let offset = -size; offset < size; offset += 150) {
+      context.beginPath();
+      context.moveTo(offset, -size);
+      context.lineTo(offset, size);
+      context.stroke();
+    }
+    context.restore();
+
+    context.beginPath();
+    context.arc(size / 2, size / 2, size * 0.41, 0, Math.PI * 2);
+    context.strokeStyle = '#d8fff7';
+    context.lineWidth = 28;
+    context.stroke();
+
+    context.beginPath();
+    context.arc(size / 2, size / 2, size * 0.32, 0, Math.PI * 2);
+    context.strokeStyle = 'rgba(254, 215, 170, 0.7)';
+    context.lineWidth = 10;
+    context.stroke();
+
+    context.save();
+    context.translate(size / 2, size / 2);
+    if (mirrored) context.scale(-1, 1);
+    context.textAlign = 'center';
+    context.textBaseline = 'middle';
+    context.fillStyle = '#ffffff';
+    context.shadowColor = 'rgba(0, 0, 0, 0.45)';
+    context.shadowBlur = 24;
+    context.font = '900 168px Poppins, Inter, Arial, sans-serif';
+    context.fillText('3dvr', 0, -20);
+    context.fillStyle = '#ccfbf1';
+    context.font = '800 96px Poppins, Inter, Arial, sans-serif';
+    context.fillText('.tech', 0, 122);
+    context.restore();
+
+    const texture = new THREE.CanvasTexture(textureCanvas);
+    texture.anisotropy = 8;
+    texture.needsUpdate = true;
+    return texture;
+  }
+
+  function resizeRenderer() {
+    const rect = root.getBoundingClientRect();
+    const width = Math.max(1, Math.floor(rect.width));
+    const height = Math.max(1, Math.floor(rect.height));
+
+    if (state.fallbackContext && !state.renderer) {
+      canvas.width = Math.floor(width * Math.min(window.devicePixelRatio || 1, 2));
+      canvas.height = Math.floor(height * Math.min(window.devicePixelRatio || 1, 2));
+      return;
+    }
+
+    if (!state.renderer || !state.camera) return;
+    state.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    state.renderer.setSize(width, height, false);
+    state.camera.aspect = width / height;
+    state.camera.updateProjectionMatrix();
+  }
+
+  function makeToken(THREE) {
+    const group = new THREE.Group();
+    const faceTexture = makeFaceTexture(THREE, false);
+    const backTexture = makeFaceTexture(THREE, true);
+    const sideMaterial = new THREE.MeshStandardMaterial({
+      color: 0x13b8b8,
+      metalness: 0.72,
+      roughness: 0.24
+    });
+    const frontMaterial = new THREE.MeshStandardMaterial({
+      map: faceTexture,
+      metalness: 0.45,
+      roughness: 0.2
+    });
+    const backMaterial = new THREE.MeshStandardMaterial({
+      map: backTexture,
+      metalness: 0.45,
+      roughness: 0.24
+    });
+
+    const body = new THREE.Mesh(
+      new THREE.CylinderGeometry(1.45, 1.45, 0.34, 128, 1, false),
+      [sideMaterial, frontMaterial, backMaterial]
+    );
+    body.rotation.x = Math.PI / 2;
+    group.add(body);
+
+    const rimMaterial = new THREE.MeshStandardMaterial({
+      color: 0xfed7aa,
+      metalness: 0.86,
+      roughness: 0.18
+    });
+    const frontRim = new THREE.Mesh(new THREE.TorusGeometry(1.47, 0.035, 16, 128), rimMaterial);
+    frontRim.position.z = 0.18;
+    group.add(frontRim);
+
+    const backRim = frontRim.clone();
+    backRim.position.z = -0.18;
+    group.add(backRim);
+
+    return group;
+  }
+
+  function animate() {
+    state.frame = window.requestAnimationFrame(animate);
+
+    if (!state.dragging) {
+      state.targetX += (state.restX - state.targetX) * 0.08;
+      state.targetY += (state.restY - state.targetY) * 0.08;
+      state.targetZ += (state.restZ - state.targetZ) * 0.08;
+    }
+
+    state.currentX += (state.targetX - state.currentX) * 0.16;
+    state.currentY += (state.targetY - state.currentY) * 0.16;
+    state.currentZ += (state.targetZ - state.currentZ) * 0.16;
+
+    if (state.token && state.renderer && state.scene && state.camera) {
+      state.token.rotation.set(state.currentX, state.currentY, state.currentZ);
+      state.renderer.render(state.scene, state.camera);
+      return;
+    }
+
+    if (state.fallbackContext) {
+      drawFallbackToken();
+    }
+  }
+
+  function startDrag(event) {
+    state.dragging = true;
+    state.lastX = event.clientX;
+    state.lastY = event.clientY;
+    root.setPointerCapture?.(event.pointerId);
+  }
+
+  function drag(event) {
+    if (!state.dragging) return;
+    window.clearTimeout(state.dragIdleTimer);
+    const dx = event.clientX - state.lastX;
+    const dy = event.clientY - state.lastY;
+    state.lastX = event.clientX;
+    state.lastY = event.clientY;
+    state.targetY += dx * 0.014;
+    state.targetX += dy * 0.014;
+    state.targetZ += (dx - dy) * 0.002;
+    state.dragIdleTimer = window.setTimeout(() => {
+      state.dragging = false;
+    }, 140);
+  }
+
+  function endDrag(event) {
+    state.dragging = false;
+    window.clearTimeout(state.dragIdleTimer);
+    root.releasePointerCapture?.(event.pointerId);
+  }
+
+  function setupKeyboard() {
+    root.addEventListener('keydown', (event) => {
+      const step = 0.22;
+      if (event.key === 'ArrowLeft') state.targetY -= step;
+      else if (event.key === 'ArrowRight') state.targetY += step;
+      else if (event.key === 'ArrowUp') state.targetX -= step;
+      else if (event.key === 'ArrowDown') state.targetX += step;
+      else return;
+
+      event.preventDefault();
+    });
+
+    root.addEventListener('keyup', () => {
+      state.targetX = state.restX;
+      state.targetY = state.restY;
+      state.targetZ = state.restZ;
+    });
+  }
+
+  function setupInteraction() {
+    if (state.interactionsReady) return;
+    state.interactionsReady = true;
+    window.addEventListener('resize', resizeRenderer);
+    root.addEventListener('pointerdown', startDrag);
+    root.addEventListener('pointermove', drag);
+    root.addEventListener('pointerup', endDrag);
+    root.addEventListener('pointercancel', endDrag);
+    root.addEventListener('lostpointercapture', endDrag);
+    window.addEventListener('pointerup', endDrag);
+    window.addEventListener('pointercancel', endDrag);
+    window.addEventListener('mouseup', () => {
+      state.dragging = false;
+    });
+    setupKeyboard();
+  }
+
+  function drawFallbackToken() {
+    const context = state.fallbackContext;
+    if (!context) return;
+
+    const width = canvas.width;
+    const height = canvas.height;
+    const size = Math.min(width, height);
+    const centerX = width / 2;
+    const centerY = height / 2;
+    const tiltX = Math.sin(state.currentX) * 0.22;
+    const tiltY = Math.sin(state.currentY) * 0.28;
+    const scaleX = Math.max(0.45, Math.cos(state.currentY) * 0.28 + 0.72);
+    const scaleY = Math.max(0.5, Math.cos(state.currentX) * 0.18 + 0.78);
+    const radius = size * 0.34;
+
+    context.clearRect(0, 0, width, height);
+    context.save();
+    context.translate(centerX, centerY);
+    context.rotate(state.currentZ);
+    context.scale(scaleX, scaleY);
+
+    const sideGradient = context.createLinearGradient(-radius, -radius, radius, radius);
+    sideGradient.addColorStop(0, '#fed7aa');
+    sideGradient.addColorStop(0.45, '#0f766e');
+    sideGradient.addColorStop(1, '#0b1020');
+
+    context.save();
+    context.translate(tiltY * radius * 0.8, tiltX * radius * 0.8 + radius * 0.08);
+    context.beginPath();
+    context.ellipse(0, 0, radius * 1.04, radius * 1.04, 0, 0, Math.PI * 2);
+    context.fillStyle = sideGradient;
+    context.shadowColor = 'rgba(0, 0, 0, 0.45)';
+    context.shadowBlur = size * 0.08;
+    context.shadowOffsetY = size * 0.035;
+    context.fill();
+    context.restore();
+
+    const faceGradient = context.createRadialGradient(-radius * 0.35, -radius * 0.45, radius * 0.05, 0, 0, radius);
+    faceGradient.addColorStop(0, '#45ffe3');
+    faceGradient.addColorStop(0.5, '#1768f2');
+    faceGradient.addColorStop(1, '#07131f');
+    context.beginPath();
+    context.ellipse(0, 0, radius, radius, 0, 0, Math.PI * 2);
+    context.fillStyle = faceGradient;
+    context.fill();
+
+    context.lineWidth = Math.max(8, size * 0.025);
+    context.strokeStyle = '#d8fff7';
+    context.stroke();
+
+    context.lineWidth = Math.max(3, size * 0.009);
+    context.strokeStyle = 'rgba(254, 215, 170, 0.78)';
+    context.beginPath();
+    context.ellipse(0, 0, radius * 0.79, radius * 0.79, 0, 0, Math.PI * 2);
+    context.stroke();
+
+    context.textAlign = 'center';
+    context.textBaseline = 'middle';
+    context.shadowColor = 'rgba(0, 0, 0, 0.42)';
+    context.shadowBlur = size * 0.025;
+    context.fillStyle = '#ffffff';
+    context.font = `900 ${Math.floor(size * 0.13)}px Poppins, Inter, Arial, sans-serif`;
+    context.fillText('3dvr', 0, -size * 0.018);
+    context.fillStyle = '#ccfbf1';
+    context.font = `800 ${Math.floor(size * 0.075)}px Poppins, Inter, Arial, sans-serif`;
+    context.fillText('.tech', 0, size * 0.1);
+    context.restore();
+  }
+
+  function markReady(mode) {
+    root.dataset.tokenReady = 'true';
+    window.__3dvrLogoToken = {
+      ready: true,
+      mode,
+      getRotation: () => ({
+        x: state.currentX,
+        y: state.currentY,
+        z: state.currentZ,
+        targetX: state.targetX,
+        targetY: state.targetY,
+        targetZ: state.targetZ
+      })
+    };
+  }
+
+  function initFallback(error) {
+    console.warn('3dvr.tech token canvas fallback active:', error);
+    state.fallbackContext = canvas.getContext('2d');
+    if (!state.fallbackContext) {
+      root.dataset.tokenReady = 'false';
+      window.__3dvrLogoToken = { ready: false };
+      return;
+    }
+
+    resizeRenderer();
+    setupInteraction();
+    markReady('canvas-fallback');
+    animate();
+  }
+
+  async function init() {
+    try {
+      const THREE = await loadThree();
+      const renderer = new THREE.WebGLRenderer({
+        canvas,
+        antialias: true,
+        alpha: true,
+        powerPreference: 'high-performance'
+      });
+      const scene = new THREE.Scene();
+      const camera = new THREE.PerspectiveCamera(38, 1, 0.1, 100);
+      camera.position.set(0, 0, 5);
+
+      const token = makeToken(THREE);
+      scene.add(token);
+      scene.add(new THREE.AmbientLight(0xe2fff8, 0.72));
+
+      const key = new THREE.DirectionalLight(0xffffff, 1.35);
+      key.position.set(2.5, 2.8, 4.5);
+      scene.add(key);
+
+      const fill = new THREE.DirectionalLight(0x99f6e4, 0.65);
+      fill.position.set(-3, -1.5, 2);
+      scene.add(fill);
+
+      state.renderer = renderer;
+      state.scene = scene;
+      state.camera = camera;
+      state.token = token;
+
+      resizeRenderer();
+      setupInteraction();
+      markReady('webgl');
+      animate();
+    } catch (error) {
+      initFallback(error);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -699,6 +699,24 @@
         rotateY(calc(var(--hero-tilt-x, 0) * 1deg))
         scale(1.01);
     }
+
+    .hero-logo-card--token {
+      max-width: 460px;
+      padding: 0;
+      background: transparent;
+      border-color: transparent;
+      box-shadow: none;
+      backdrop-filter: none;
+      cursor: default;
+    }
+
+    .hero-logo-card--token:hover,
+    .hero-logo-card--token:focus-visible {
+      background: transparent;
+      border-color: transparent;
+      box-shadow: none;
+    }
+
     .hero-logo-card img {
       width: clamp(112px, 28vw, 156px);
       height: auto;
@@ -710,6 +728,54 @@
       transition: transform 120ms ease;
       will-change: transform;
     }
+
+    .hero-token {
+      position: relative;
+      width: clamp(230px, 54vw, 360px);
+      aspect-ratio: 1;
+      border-radius: 50%;
+      cursor: grab;
+      touch-action: none;
+      outline: none;
+      filter: drop-shadow(0 30px 45px rgba(0,0,0,0.32));
+    }
+
+    .hero-token:active {
+      cursor: grabbing;
+    }
+
+    .hero-token:focus-visible {
+      box-shadow: 0 0 0 3px rgba(0,255,200,0.42);
+    }
+
+    .hero-token__canvas,
+    .hero-token__fallback {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+    }
+
+    .hero-token__canvas {
+      display: block;
+      opacity: 0;
+      transition: opacity 220ms ease;
+    }
+
+    .hero-token[data-token-ready="true"] .hero-token__canvas {
+      opacity: 1;
+    }
+
+    .hero-token__fallback {
+      object-fit: contain;
+      opacity: 1;
+      transition: opacity 220ms ease;
+    }
+
+    .hero-token[data-token-ready="true"] .hero-token__fallback {
+      opacity: 0;
+    }
+
     .hero-brand-wordmark {
       display: flex;
       flex-direction: column;
@@ -1535,12 +1601,21 @@
       <div class="hero-intro">
         <p id="heroEyebrow" class="hero-eyebrow">Websites. Apps. Direct support.</p>
       </div>
-      <div class="hero-visual" aria-hidden="true">
-        <div class="hero-logo-card">
+      <div class="hero-visual">
+        <div class="hero-logo-card hero-logo-card--token">
           <div class="hero-spark hero-spark--top"></div>
           <div class="hero-spark hero-spark--bottom"></div>
           <div class="hero-brand-wordmark" aria-label="3dvr.tech">
-            <img src="/assets/logo-3dvr.svg" alt="" />
+            <div
+              class="hero-token"
+              data-3dvr-token
+              role="img"
+              tabindex="0"
+              aria-label="Interactive 3dvr.tech 3D token. Drag to spin it; release to reset."
+            >
+              <canvas class="hero-token__canvas" data-3dvr-token-canvas></canvas>
+              <img class="hero-token__fallback" src="/assets/logo-3dvr.svg" alt="" />
+            </div>
             <strong>3dvr<span>.tech</span></strong>
           </div>
           <p>
@@ -2381,5 +2456,6 @@
   </script>
   <script src="/pwa.js"></script>
   <script src="subscribe/portal-links.js"></script>
+  <script src="homepage-logo-token.js"></script>
 </body>
 </html>

--- a/tests/homepage-growth.test.js
+++ b/tests/homepage-growth.test.js
@@ -17,7 +17,7 @@ test('homepage ships Gun-backed experiment and feedback plumbing', async () => {
   assert.match(html, /data-growth-cta="sticky-start-free"/);
   assert.match(html, /data-growth-cta="start-free-primary"/);
   assert.match(html, /data-growth-cta="see-plans"/);
-  assert.match(html, /class="hero-logo-card"/);
+  assert.match(html, /class="hero-logo-card(?:\s|")/);
   assert.match(html, /A clear place to land when you need a site, support, or a launch plan\./);
   assert.doesNotMatch(html, /data-growth-cta="enter-3dvr-world"/);
   assert.match(html, /data-growth-cta="plan-free"/);

--- a/tests/logo-branding.test.js
+++ b/tests/logo-branding.test.js
@@ -13,8 +13,27 @@ describe('3dvr-web logo branding', () => {
     assert.match(html, /class="site-brand"[^>]+aria-label="3dvr\.tech home"/);
     assert.match(html, /<span class="site-brand__name">3dvr<span>\.tech<\/span><\/span>/);
     assert.match(html, /<strong>3dvr<span>\.tech<\/span><\/strong>/);
+    assert.match(html, /data-3dvr-token/);
+    assert.match(html, /data-3dvr-token-canvas/);
+    assert.match(html, /Interactive 3dvr\.tech 3D token/);
+    assert.match(html, /homepage-logo-token\.js/);
     assert.match(html, /app-boot-enabled/);
     assert.match(html, /display-mode: standalone/);
     assert.match(html, /document\.referrer\.startsWith\('android-app:\/\/'\)/);
+  });
+
+  it('ships a touch and mouse driven Three.js token for the homepage logo', async () => {
+    const token = await readFile(new URL('../homepage-logo-token.js', import.meta.url), 'utf8');
+
+    assert.match(token, /THREE_CDN_URL/);
+    assert.match(token, /three\.js\/r128\/three\.min\.js/);
+    assert.match(token, /CylinderGeometry/);
+    assert.match(token, /TorusGeometry/);
+    assert.match(token, /CanvasTexture/);
+    assert.match(token, /pointerdown/);
+    assert.match(token, /pointermove/);
+    assert.match(token, /releasePointerCapture/);
+    assert.match(token, /state\.restX - state\.targetX/);
+    assert.match(token, /__3dvrLogoToken/);
   });
 });


### PR DESCRIPTION
## Summary
- replaces the flat homepage logo image in the hero with an interactive 3dvr.tech token
- uses Three.js for the full 3D token in WebGL-capable browsers
- adds a dimensional canvas fallback for browsers/environments without WebGL
- supports mouse, touch/pointer drag, keyboard arrow nudges, and snap-back to the default pose

## Tests
- `node --check homepage-logo-token.js`
- `node --test tests/logo-branding.test.js tests/homepage-growth.test.js tests/service-worker.test.js`
- `git diff --check`
- visual/canvas smoke check with Playwright under Xvfb for desktop and mobile viewports: verified nonblank canvas pixels, drag rotation, and snap-back behavior

Note: this CI/container browser cannot create a WebGL context, so the Playwright visual pass verified the canvas fallback path. The production WebGL path remains implemented with Three.js and falls back cleanly when WebGL is unavailable.