### PR TITLE
Fix homepage 3D logo framing

### DIFF
--- a/homepage-logo-token.js
+++ b/homepage-logo-token.js
@@ -1,5 +1,6 @@
 (function () {
   const THREE_CDN_URL = 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js';
+  const FACE_TEXTURE_ROTATION = -Math.PI / 2;
   const root = document.querySelector('[data-3dvr-token]');
   const canvas = document.querySelector('[data-3dvr-token-canvas]');
 
@@ -83,6 +84,7 @@
     context.save();
     context.translate(size / 2, size / 2);
     if (mirrored) context.scale(-1, 1);
+    context.rotate(FACE_TEXTURE_ROTATION);
     context.textAlign = 'center';
     context.textBaseline = 'middle';
     context.fillStyle = '#ffffff';

--- a/index.html
+++ b/index.html
@@ -444,10 +444,12 @@
       text-transform: uppercase;
       font-weight: 600;
       color: rgba(255,255,255,0.8);
-      display: inline-flex;
-      justify-content: center;
+      display: block;
       text-align: center;
       width: 100%;
+      max-width: min(100%, 34rem);
+      line-height: 1.8;
+      overflow-wrap: anywhere;
     }
     .hero h1 {
       font-size: clamp(3rem, 7vw, 4.5rem);
@@ -717,7 +719,7 @@
       box-shadow: none;
     }
 
-    .hero-logo-card img {
+    .hero-logo-card > img {
       width: clamp(112px, 28vw, 156px);
       height: auto;
       filter: drop-shadow(0 0 28px rgba(0,255,200,0.45));
@@ -731,13 +733,15 @@
 
     .hero-token {
       position: relative;
-      width: clamp(230px, 54vw, 360px);
+      width: clamp(200px, min(50vw, 36vh), 340px);
+      max-width: 100%;
       aspect-ratio: 1;
       border-radius: 50%;
       cursor: grab;
       touch-action: none;
       outline: none;
       filter: drop-shadow(0 30px 45px rgba(0,0,0,0.32));
+      isolation: isolate;
     }
 
     .hero-token:active {
@@ -770,6 +774,10 @@
       object-fit: contain;
       opacity: 1;
       transition: opacity 220ms ease;
+      animation: none;
+      filter: none;
+      transform: none;
+      pointer-events: none;
     }
 
     .hero-token[data-token-ready="true"] .hero-token__fallback {
@@ -781,13 +789,16 @@
       flex-direction: column;
       align-items: center;
       gap: 0.55rem;
+      width: min(100%, 34rem);
     }
     .hero-brand-wordmark strong {
       font-family: 'Poppins', sans-serif;
-      font-size: clamp(2.35rem, 10vw, 4.9rem);
+      font-size: clamp(2.25rem, 9.2vw, 4.6rem);
       line-height: 0.95;
       letter-spacing: 0;
       text-shadow: 0 18px 46px rgba(0,0,0,0.3);
+      max-width: 100%;
+      white-space: nowrap;
     }
     .hero-brand-wordmark strong span {
       color: var(--accent);
@@ -866,6 +877,31 @@
         width: min(92vw, 420px);
         padding: 2.8rem 2.4rem;
         gap: 1.4rem;
+      }
+      .hero-logo-card--token {
+        width: min(100%, 420px);
+        padding: 0;
+        gap: 1rem;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .hero {
+        padding-inline: clamp(1rem, 5vw, 1.25rem);
+      }
+      .hero-eyebrow {
+        font-size: clamp(0.76rem, 3.1vw, 0.88rem);
+        letter-spacing: clamp(0.12em, 0.8vw, 0.18em);
+        line-height: 1.75;
+      }
+      .hero-brand-wordmark {
+        gap: 0.45rem;
+      }
+      .hero-brand-wordmark strong {
+        font-size: clamp(2.2rem, 11vw, 3.25rem);
+      }
+      .hero-token {
+        width: clamp(190px, 56vw, 230px);
       }
     }
 

--- a/tests/logo-branding.test.js
+++ b/tests/logo-branding.test.js
@@ -16,6 +16,8 @@ describe('3dvr-web logo branding', () => {
     assert.match(html, /data-3dvr-token/);
     assert.match(html, /data-3dvr-token-canvas/);
     assert.match(html, /Interactive 3dvr\.tech 3D token/);
+    assert.match(html, /\.hero-logo-card > img/);
+    assert.match(html, /\.hero-token\[data-token-ready="true"\] \.hero-token__fallback/);
     assert.match(html, /homepage-logo-token\.js/);
     assert.match(html, /app-boot-enabled/);
     assert.match(html, /display-mode: standalone/);
@@ -27,6 +29,7 @@ describe('3dvr-web logo branding', () => {
 
     assert.match(token, /THREE_CDN_URL/);
     assert.match(token, /three\.js\/r128\/three\.min\.js/);
+    assert.match(token, /FACE_TEXTURE_ROTATION/);
     assert.match(token, /CylinderGeometry/);
     assert.match(token, /TorusGeometry/);
     assert.match(token, /CanvasTexture/);

--- a/tests/playwright/homepage-mobile.spec.js
+++ b/tests/playwright/homepage-mobile.spec.js
@@ -65,4 +65,49 @@ test.describe('homepage mobile sticky CTA', () => {
     expect(layout.maxChipRight).toBeLessThanOrEqual(layout.gridRight + 1);
     expect(layout.maxChipWidth).toBeLessThan(layout.gridWidth);
   });
+
+  test('keeps the 3D hero logo framed on mobile', async ({ page }, testInfo) => {
+    test.skip(!isMobileProject(testInfo), 'Mobile-only homepage check');
+
+    await page.goto('/');
+    await page.waitForFunction(() => window.__3dvrLogoToken?.ready === true);
+    await page.waitForTimeout(300);
+
+    const layout = await page.evaluate(() => {
+      const selectors = [
+        '.hero-eyebrow',
+        '.hero-token',
+        '.hero-brand-wordmark strong',
+        '.hero-logo-card--token p',
+      ];
+      const rects = selectors.map((selector) => {
+        const element = document.querySelector(selector);
+        const rect = element?.getBoundingClientRect();
+
+        return {
+          selector,
+          left: Math.round(rect?.left ?? 0),
+          right: Math.round(rect?.right ?? 0),
+          width: Math.round(rect?.width ?? 0),
+        };
+      });
+      const fallback = document.querySelector('.hero-token__fallback');
+
+      return {
+        innerWidth: window.innerWidth,
+        scrollWidth: document.documentElement.scrollWidth,
+        fallbackOpacity: Number.parseFloat(getComputedStyle(fallback).opacity),
+        rects,
+      };
+    });
+
+    expect(layout.scrollWidth).toBeLessThanOrEqual(layout.innerWidth + 1);
+    expect(layout.fallbackOpacity).toBeLessThan(0.1);
+
+    for (const rect of layout.rects) {
+      expect(rect.width, `${rect.selector} should render with width`).toBeGreaterThan(0);
+      expect(rect.left, `${rect.selector} should not clip left`).toBeGreaterThanOrEqual(0);
+      expect(rect.right, `${rect.selector} should not clip right`).toBeLessThanOrEqual(layout.innerWidth);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- hide the token fallback image after the WebGL/canvas token is ready so the square app icon no longer overlaps the coin
- rotate the token face texture so the 3dvr.tech text is upright at rest
- tighten mobile logo, eyebrow, and wordmark bounds and add a Playwright mobile framing check

## Tests
- `node --test tests/logo-branding.test.js`
- `npx playwright test --project=chromium-fold-closed tests/playwright/homepage-mobile.spec.js`

## Notes
- `npm run test:unit` still has two unrelated current-main failures: `tests/life-plan.test.js` copy expectation and `tests/vercel-insights-tag.test.js` missing the insights tag on `3dvr-world/prize.html`.