### PR TITLE
Make homepage logo spin from a front pose

### DIFF
--- a/homepage-logo-token.js
+++ b/homepage-logo-token.js
@@ -1,6 +1,7 @@
 (function () {
   const THREE_CDN_URL = 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js';
   const FACE_TEXTURE_ROTATION = -Math.PI / 2;
+  const IDLE_SPIN_SPEED = (Math.PI * 2) / 56000;
   const root = document.querySelector('[data-3dvr-token]');
   const canvas = document.querySelector('[data-3dvr-token-canvas]');
 
@@ -10,15 +11,17 @@
     dragging: false,
     lastX: 0,
     lastY: 0,
-    targetX: -0.2,
-    targetY: 0.38,
-    targetZ: -0.08,
-    currentX: -0.2,
-    currentY: 0.38,
-    currentZ: -0.08,
-    restX: -0.2,
-    restY: 0.38,
-    restZ: -0.08,
+    targetX: 0,
+    targetY: 0,
+    targetZ: 0,
+    currentX: 0,
+    currentY: 0,
+    currentZ: 0,
+    restX: 0,
+    restY: 0,
+    restZ: 0,
+    idleSpin: 0,
+    lastTimestamp: 0,
     renderer: null,
     fallbackContext: null,
     camera: null,
@@ -164,8 +167,31 @@
     return group;
   }
 
-  function animate() {
+  function updateIdleSpin(timestamp) {
+    if (!state.lastTimestamp) {
+      state.lastTimestamp = timestamp;
+      return;
+    }
+
+    const elapsed = Math.min(timestamp - state.lastTimestamp, 64);
+    state.lastTimestamp = timestamp;
+
+    if (!state.dragging) {
+      state.idleSpin = (state.idleSpin + elapsed * IDLE_SPIN_SPEED) % (Math.PI * 2);
+    }
+  }
+
+  function getRenderRotation() {
+    return {
+      x: state.currentX,
+      y: state.currentY,
+      z: state.currentZ + state.idleSpin
+    };
+  }
+
+  function animate(timestamp = 0) {
     state.frame = window.requestAnimationFrame(animate);
+    updateIdleSpin(timestamp);
 
     if (!state.dragging) {
       state.targetX += (state.restX - state.targetX) * 0.08;
@@ -178,7 +204,8 @@
     state.currentZ += (state.targetZ - state.currentZ) * 0.16;
 
     if (state.token && state.renderer && state.scene && state.camera) {
-      state.token.rotation.set(state.currentX, state.currentY, state.currentZ);
+      const rotation = getRenderRotation();
+      state.token.rotation.set(rotation.x, rotation.y, rotation.z);
       state.renderer.render(state.scene, state.camera);
       return;
     }
@@ -270,7 +297,7 @@
     context.clearRect(0, 0, width, height);
     context.save();
     context.translate(centerX, centerY);
-    context.rotate(state.currentZ);
+    context.rotate(state.currentZ + state.idleSpin);
     context.scale(scaleX, scaleY);
 
     const sideGradient = context.createLinearGradient(-radius, -radius, radius, radius);
@@ -326,14 +353,22 @@
     window.__3dvrLogoToken = {
       ready: true,
       mode,
-      getRotation: () => ({
-        x: state.currentX,
-        y: state.currentY,
-        z: state.currentZ,
-        targetX: state.targetX,
-        targetY: state.targetY,
-        targetZ: state.targetZ
-      })
+      getRotation: () => {
+        const rotation = getRenderRotation();
+
+        return {
+          x: rotation.x,
+          y: rotation.y,
+          z: rotation.z,
+          manualX: state.currentX,
+          manualY: state.currentY,
+          manualZ: state.currentZ,
+          idleSpin: state.idleSpin,
+          targetX: state.targetX,
+          targetY: state.targetY,
+          targetZ: state.targetZ
+        };
+      }
     };
   }
 

--- a/tests/logo-branding.test.js
+++ b/tests/logo-branding.test.js
@@ -30,9 +30,15 @@ describe('3dvr-web logo branding', () => {
     assert.match(token, /THREE_CDN_URL/);
     assert.match(token, /three\.js\/r128\/three\.min\.js/);
     assert.match(token, /FACE_TEXTURE_ROTATION/);
+    assert.match(token, /IDLE_SPIN_SPEED = \(Math\.PI \* 2\) \/ 56000/);
     assert.match(token, /CylinderGeometry/);
     assert.match(token, /TorusGeometry/);
     assert.match(token, /CanvasTexture/);
+    assert.match(token, /targetX: 0/);
+    assert.match(token, /targetY: 0/);
+    assert.match(token, /targetZ: 0/);
+    assert.match(token, /idleSpin/);
+    assert.match(token, /getRenderRotation/);
     assert.match(token, /pointerdown/);
     assert.match(token, /pointermove/);
     assert.match(token, /releasePointerCapture/);

--- a/tests/playwright/homepage-mobile.spec.js
+++ b/tests/playwright/homepage-mobile.spec.js
@@ -110,4 +110,35 @@ test.describe('homepage mobile sticky CTA', () => {
       expect(rect.right, `${rect.selector} should not clip right`).toBeLessThanOrEqual(layout.innerWidth);
     }
   });
+
+  test('returns the 3D token to a straight idle spin after interaction', async ({ page }, testInfo) => {
+    test.skip(!isMobileProject(testInfo), 'Mobile-only homepage check');
+
+    await page.goto('/');
+    await page.waitForFunction(() => window.__3dvrLogoToken?.ready === true);
+    await page.waitForTimeout(300);
+
+    const initial = await page.evaluate(() => window.__3dvrLogoToken.getRotation());
+    await page.waitForTimeout(900);
+    const spinning = await page.evaluate(() => window.__3dvrLogoToken.getRotation());
+
+    expect(Math.abs(initial.manualX)).toBeLessThan(0.02);
+    expect(Math.abs(initial.manualY)).toBeLessThan(0.02);
+    expect(spinning.idleSpin).toBeGreaterThan(initial.idleSpin + 0.06);
+
+    const token = page.locator('.hero-token');
+    const box = await token.boundingBox();
+    expect(box).not.toBeNull();
+
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width / 2 + 95, box.y + box.height / 2 + 48, { steps: 6 });
+    await page.mouse.up();
+    await page.waitForTimeout(1800);
+
+    const released = await page.evaluate(() => window.__3dvrLogoToken.getRotation());
+    expect(Math.abs(released.manualX)).toBeLessThan(0.08);
+    expect(Math.abs(released.manualY)).toBeLessThan(0.08);
+    expect(released.idleSpin).toBeGreaterThan(spinning.idleSpin);
+  });
 });


### PR DESCRIPTION
## Summary
- set the homepage token's default/resting manual rotation to a straight-on pose
- add a slow time-based idle spin that resumes after drag/release
- expose idle/manual rotation state and cover the behavior in the mobile Playwright check

## Tests
- `node --test tests/logo-branding.test.js`
- `npx playwright test --project=chromium-fold-closed tests/playwright/homepage-mobile.spec.js`

## Visual check
- local 390x844 Playwright render confirmed the token is front-facing with `manualX/manualY/manualZ` at `0` and idle spin advancing.