### PR TITLE
Make homepage logo spin like a coin

### DIFF
--- a/homepage-logo-token.js
+++ b/homepage-logo-token.js
@@ -1,7 +1,9 @@
 (function () {
   const THREE_CDN_URL = 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js';
   const FACE_TEXTURE_ROTATION = -Math.PI / 2;
-  const IDLE_SPIN_SPEED = (Math.PI * 2) / 56000;
+  const IDLE_QUARTER_SPIN_SPEED = (Math.PI * 2) / 18000;
+  const IDLE_WOBBLE_X = 0.08;
+  const IDLE_WOBBLE_Z = 0.045;
   const root = document.querySelector('[data-3dvr-token]');
   const canvas = document.querySelector('[data-3dvr-token-canvas]');
 
@@ -127,7 +129,7 @@
   function makeToken(THREE) {
     const group = new THREE.Group();
     const faceTexture = makeFaceTexture(THREE, false);
-    const backTexture = makeFaceTexture(THREE, true);
+    const backTexture = makeFaceTexture(THREE, false);
     const sideMaterial = new THREE.MeshStandardMaterial({
       color: 0x13b8b8,
       metalness: 0.72,
@@ -177,15 +179,20 @@
     state.lastTimestamp = timestamp;
 
     if (!state.dragging) {
-      state.idleSpin = (state.idleSpin + elapsed * IDLE_SPIN_SPEED) % (Math.PI * 2);
+      state.idleSpin = (state.idleSpin + elapsed * IDLE_QUARTER_SPIN_SPEED) % (Math.PI * 2);
     }
   }
 
   function getRenderRotation() {
+    const wobbleX = Math.sin(state.idleSpin * 1.6) * IDLE_WOBBLE_X;
+    const wobbleZ = Math.sin(state.idleSpin * 0.75) * IDLE_WOBBLE_Z;
+
     return {
-      x: state.currentX,
-      y: state.currentY,
-      z: state.currentZ + state.idleSpin
+      x: state.currentX + wobbleX,
+      y: state.currentY + state.idleSpin,
+      z: state.currentZ + wobbleZ,
+      wobbleX,
+      wobbleZ
     };
   }
 
@@ -288,16 +295,17 @@
     const size = Math.min(width, height);
     const centerX = width / 2;
     const centerY = height / 2;
-    const tiltX = Math.sin(state.currentX) * 0.22;
-    const tiltY = Math.sin(state.currentY) * 0.28;
-    const scaleX = Math.max(0.45, Math.cos(state.currentY) * 0.28 + 0.72);
-    const scaleY = Math.max(0.5, Math.cos(state.currentX) * 0.18 + 0.78);
+    const rotation = getRenderRotation();
+    const tiltX = Math.sin(rotation.x) * 0.22;
+    const tiltY = Math.sin(rotation.y) * 0.28;
+    const scaleX = Math.max(0.18, Math.abs(Math.cos(rotation.y)) * 0.82 + 0.18);
+    const scaleY = Math.max(0.5, Math.cos(rotation.x) * 0.18 + 0.78);
     const radius = size * 0.34;
 
     context.clearRect(0, 0, width, height);
     context.save();
     context.translate(centerX, centerY);
-    context.rotate(state.currentZ + state.idleSpin);
+    context.rotate(rotation.z);
     context.scale(scaleX, scaleY);
 
     const sideGradient = context.createLinearGradient(-radius, -radius, radius, radius);
@@ -364,6 +372,8 @@
           manualY: state.currentY,
           manualZ: state.currentZ,
           idleSpin: state.idleSpin,
+          wobbleX: rotation.wobbleX,
+          wobbleZ: rotation.wobbleZ,
           targetX: state.targetX,
           targetY: state.targetY,
           targetZ: state.targetZ

--- a/tests/logo-branding.test.js
+++ b/tests/logo-branding.test.js
@@ -30,7 +30,9 @@ describe('3dvr-web logo branding', () => {
     assert.match(token, /THREE_CDN_URL/);
     assert.match(token, /three\.js\/r128\/three\.min\.js/);
     assert.match(token, /FACE_TEXTURE_ROTATION/);
-    assert.match(token, /IDLE_SPIN_SPEED = \(Math\.PI \* 2\) \/ 56000/);
+    assert.match(token, /IDLE_QUARTER_SPIN_SPEED = \(Math\.PI \* 2\) \/ 18000/);
+    assert.match(token, /IDLE_WOBBLE_X/);
+    assert.match(token, /IDLE_WOBBLE_Z/);
     assert.match(token, /CylinderGeometry/);
     assert.match(token, /TorusGeometry/);
     assert.match(token, /CanvasTexture/);

--- a/tests/playwright/homepage-mobile.spec.js
+++ b/tests/playwright/homepage-mobile.spec.js
@@ -111,7 +111,7 @@ test.describe('homepage mobile sticky CTA', () => {
     }
   });
 
-  test('returns the 3D token to a straight idle spin after interaction', async ({ page }, testInfo) => {
+  test('returns the 3D token to a quarter-style idle spin after interaction', async ({ page }, testInfo) => {
     test.skip(!isMobileProject(testInfo), 'Mobile-only homepage check');
 
     await page.goto('/');
@@ -124,7 +124,10 @@ test.describe('homepage mobile sticky CTA', () => {
 
     expect(Math.abs(initial.manualX)).toBeLessThan(0.02);
     expect(Math.abs(initial.manualY)).toBeLessThan(0.02);
+    expect(Math.abs(initial.manualZ)).toBeLessThan(0.02);
     expect(spinning.idleSpin).toBeGreaterThan(initial.idleSpin + 0.06);
+    expect(spinning.y).toBeGreaterThan(initial.y + 0.25);
+    expect(Math.abs(spinning.z - spinning.manualZ)).toBeLessThan(0.06);
 
     const token = page.locator('.hero-token');
     const box = await token.boundingBox();
@@ -139,6 +142,8 @@ test.describe('homepage mobile sticky CTA', () => {
     const released = await page.evaluate(() => window.__3dvrLogoToken.getRotation());
     expect(Math.abs(released.manualX)).toBeLessThan(0.08);
     expect(Math.abs(released.manualY)).toBeLessThan(0.08);
+    expect(Math.abs(released.manualZ)).toBeLessThan(0.08);
     expect(released.idleSpin).toBeGreaterThan(spinning.idleSpin);
+    expect(released.y).toBeGreaterThan(spinning.y);
   });
 });


### PR DESCRIPTION
## Summary
- move the homepage token idle spin from flat `z` rotation to vertical `y` rotation so it turns like a coin
- add a small controlled wobble for a flicked-quarter feel without leaving the manual rest pose tilted
- keep the back texture readable during the turn and update the mobile regression check for quarter-style motion

## Tests
- `node --test tests/logo-branding.test.js`
- `npx playwright test --project=chromium-fold-closed tests/playwright/homepage-mobile.spec.js`

## Visual check
- local Playwright frames confirmed the token turns edge-on/back-on like a coin and no longer spins as a flat face.