### PR TITLE
Smooth homepage coin spin wobble

### DIFF
--- a/homepage-logo-token.js
+++ b/homepage-logo-token.js
@@ -2,8 +2,8 @@
   const THREE_CDN_URL = 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js';
   const FACE_TEXTURE_ROTATION = -Math.PI / 2;
   const IDLE_QUARTER_SPIN_SPEED = (Math.PI * 2) / 18000;
-  const IDLE_WOBBLE_X = 0.08;
-  const IDLE_WOBBLE_Z = 0.045;
+  const IDLE_WOBBLE_X = 0.025;
+  const IDLE_WOBBLE_Z = 0.012;
   const root = document.querySelector('[data-3dvr-token]');
   const canvas = document.querySelector('[data-3dvr-token-canvas]');
 
@@ -179,7 +179,7 @@
     state.lastTimestamp = timestamp;
 
     if (!state.dragging) {
-      state.idleSpin = (state.idleSpin + elapsed * IDLE_QUARTER_SPIN_SPEED) % (Math.PI * 2);
+      state.idleSpin += elapsed * IDLE_QUARTER_SPIN_SPEED;
     }
   }
 

--- a/tests/logo-branding.test.js
+++ b/tests/logo-branding.test.js
@@ -31,8 +31,8 @@ describe('3dvr-web logo branding', () => {
     assert.match(token, /three\.js\/r128\/three\.min\.js/);
     assert.match(token, /FACE_TEXTURE_ROTATION/);
     assert.match(token, /IDLE_QUARTER_SPIN_SPEED = \(Math\.PI \* 2\) \/ 18000/);
-    assert.match(token, /IDLE_WOBBLE_X/);
-    assert.match(token, /IDLE_WOBBLE_Z/);
+    assert.match(token, /IDLE_WOBBLE_X = 0\.025/);
+    assert.match(token, /IDLE_WOBBLE_Z = 0\.012/);
     assert.match(token, /CylinderGeometry/);
     assert.match(token, /TorusGeometry/);
     assert.match(token, /CanvasTexture/);
@@ -40,6 +40,8 @@ describe('3dvr-web logo branding', () => {
     assert.match(token, /targetY: 0/);
     assert.match(token, /targetZ: 0/);
     assert.match(token, /idleSpin/);
+    assert.match(token, /state\.idleSpin \+= elapsed \* IDLE_QUARTER_SPIN_SPEED/);
+    assert.doesNotMatch(token, /idleSpin = .*% \(Math\.PI \* 2\)/);
     assert.match(token, /getRenderRotation/);
     assert.match(token, /pointerdown/);
     assert.match(token, /pointermove/);

--- a/tests/playwright/homepage-mobile.spec.js
+++ b/tests/playwright/homepage-mobile.spec.js
@@ -127,7 +127,8 @@ test.describe('homepage mobile sticky CTA', () => {
     expect(Math.abs(initial.manualZ)).toBeLessThan(0.02);
     expect(spinning.idleSpin).toBeGreaterThan(initial.idleSpin + 0.06);
     expect(spinning.y).toBeGreaterThan(initial.y + 0.25);
-    expect(Math.abs(spinning.z - spinning.manualZ)).toBeLessThan(0.06);
+    expect(Math.abs(spinning.wobbleX)).toBeLessThan(0.026);
+    expect(Math.abs(spinning.z - spinning.manualZ)).toBeLessThan(0.013);
 
     const token = page.locator('.hero-token');
     const box = await token.boundingBox();


### PR DESCRIPTION
## Summary
- reduce the homepage coin-spin wobble amplitude so the motion is calmer
- remove the short modulo wrap that made the wobble snap around the old full-spin point
- update tests to guard against reintroducing the short idle-spin reset

## Tests
- `node --test tests/logo-branding.test.js`
- `npx playwright test --project=chromium-fold-closed tests/playwright/homepage-mobile.spec.js`

## Visual check
- local Playwright render waited past the old reset point; `idleSpin` continued increasing and the token did not hit the old wrap snap.