### PR TITLE
Add momentum to homepage logo spin

### DIFF
--- a/homepage-logo-token.js
+++ b/homepage-logo-token.js
@@ -4,6 +4,10 @@
   const IDLE_QUARTER_SPIN_SPEED = (Math.PI * 2) / 18000;
   const IDLE_WOBBLE_X = 0.025;
   const IDLE_WOBBLE_Z = 0.012;
+  const DRAG_SPIN_FACTOR = 0.018;
+  const MAX_SPIN_MOMENTUM = 0.014;
+  const MIN_SPIN_MOMENTUM = 0.00008;
+  const SPIN_MOMENTUM_DECAY = 0.992;
   const root = document.querySelector('[data-3dvr-token]');
   const canvas = document.querySelector('[data-3dvr-token-canvas]');
 
@@ -23,16 +27,21 @@
     restY: 0,
     restZ: 0,
     idleSpin: 0,
+    spinVelocityY: 0,
     lastTimestamp: 0,
+    lastDragTimestamp: 0,
     renderer: null,
     fallbackContext: null,
     camera: null,
     scene: null,
     token: null,
     frame: 0,
-    interactionsReady: false,
-    dragIdleTimer: 0
+    interactionsReady: false
   };
+
+  function clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
+  }
 
   function loadThree() {
     if (window.THREE) return Promise.resolve(window.THREE);
@@ -178,8 +187,17 @@
     const elapsed = Math.min(timestamp - state.lastTimestamp, 64);
     state.lastTimestamp = timestamp;
 
-    if (!state.dragging) {
-      state.idleSpin += elapsed * IDLE_QUARTER_SPIN_SPEED;
+    if (state.dragging) {
+      return;
+    }
+
+    state.idleSpin += elapsed * (IDLE_QUARTER_SPIN_SPEED + state.spinVelocityY);
+
+    if (state.spinVelocityY !== 0) {
+      state.spinVelocityY *= Math.pow(SPIN_MOMENTUM_DECAY, elapsed / 16.67);
+      if (Math.abs(state.spinVelocityY) < MIN_SPIN_MOMENTUM) {
+        state.spinVelocityY = 0;
+      }
     }
   }
 
@@ -226,27 +244,34 @@
     state.dragging = true;
     state.lastX = event.clientX;
     state.lastY = event.clientY;
+    state.lastDragTimestamp = event.timeStamp || performance.now();
+    state.spinVelocityY = 0;
     root.setPointerCapture?.(event.pointerId);
   }
 
   function drag(event) {
     if (!state.dragging) return;
-    window.clearTimeout(state.dragIdleTimer);
     const dx = event.clientX - state.lastX;
     const dy = event.clientY - state.lastY;
+    const timestamp = event.timeStamp || performance.now();
+    const elapsed = Math.max(16, Math.min(timestamp - state.lastDragTimestamp, 80));
+    const spinDelta = dx * DRAG_SPIN_FACTOR;
     state.lastX = event.clientX;
     state.lastY = event.clientY;
-    state.targetY += dx * 0.014;
-    state.targetX += dy * 0.014;
-    state.targetZ += (dx - dy) * 0.002;
-    state.dragIdleTimer = window.setTimeout(() => {
-      state.dragging = false;
-    }, 140);
+    state.lastDragTimestamp = timestamp;
+    state.idleSpin += spinDelta;
+    state.spinVelocityY = clamp(
+      state.spinVelocityY * 0.35 + (spinDelta / elapsed) * 0.65,
+      -MAX_SPIN_MOMENTUM,
+      MAX_SPIN_MOMENTUM
+    );
+    state.targetY += spinDelta * 0.18;
+    state.targetX += dy * 0.012;
+    state.targetZ += (dx - dy) * 0.0015;
   }
 
   function endDrag(event) {
     state.dragging = false;
-    window.clearTimeout(state.dragIdleTimer);
     root.releasePointerCapture?.(event.pointerId);
   }
 
@@ -372,6 +397,7 @@
           manualY: state.currentY,
           manualZ: state.currentZ,
           idleSpin: state.idleSpin,
+          spinVelocityY: state.spinVelocityY,
           wobbleX: rotation.wobbleX,
           wobbleZ: rotation.wobbleZ,
           targetX: state.targetX,

--- a/tests/logo-branding.test.js
+++ b/tests/logo-branding.test.js
@@ -33,6 +33,9 @@ describe('3dvr-web logo branding', () => {
     assert.match(token, /IDLE_QUARTER_SPIN_SPEED = \(Math\.PI \* 2\) \/ 18000/);
     assert.match(token, /IDLE_WOBBLE_X = 0\.025/);
     assert.match(token, /IDLE_WOBBLE_Z = 0\.012/);
+    assert.match(token, /DRAG_SPIN_FACTOR = 0\.018/);
+    assert.match(token, /MAX_SPIN_MOMENTUM = 0\.014/);
+    assert.match(token, /SPIN_MOMENTUM_DECAY = 0\.992/);
     assert.match(token, /CylinderGeometry/);
     assert.match(token, /TorusGeometry/);
     assert.match(token, /CanvasTexture/);
@@ -40,7 +43,8 @@ describe('3dvr-web logo branding', () => {
     assert.match(token, /targetY: 0/);
     assert.match(token, /targetZ: 0/);
     assert.match(token, /idleSpin/);
-    assert.match(token, /state\.idleSpin \+= elapsed \* IDLE_QUARTER_SPIN_SPEED/);
+    assert.match(token, /spinVelocityY/);
+    assert.match(token, /state\.idleSpin \+= elapsed \* \(IDLE_QUARTER_SPIN_SPEED \+ state\.spinVelocityY\)/);
     assert.doesNotMatch(token, /idleSpin = .*% \(Math\.PI \* 2\)/);
     assert.match(token, /getRenderRotation/);
     assert.match(token, /pointerdown/);

--- a/tests/playwright/homepage-mobile.spec.js
+++ b/tests/playwright/homepage-mobile.spec.js
@@ -136,15 +136,21 @@ test.describe('homepage mobile sticky CTA', () => {
 
     await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
     await page.mouse.down();
-    await page.mouse.move(box.x + box.width / 2 + 95, box.y + box.height / 2 + 48, { steps: 6 });
+    await page.mouse.move(box.x + box.width / 2 + 140, box.y + box.height / 2 + 28, { steps: 2 });
     await page.mouse.up();
+    await page.waitForTimeout(180);
+
+    const boosted = await page.evaluate(() => window.__3dvrLogoToken.getRotation());
+    expect(boosted.spinVelocityY).toBeGreaterThan(0.002);
+
     await page.waitForTimeout(1800);
 
     const released = await page.evaluate(() => window.__3dvrLogoToken.getRotation());
     expect(Math.abs(released.manualX)).toBeLessThan(0.08);
     expect(Math.abs(released.manualY)).toBeLessThan(0.08);
     expect(Math.abs(released.manualZ)).toBeLessThan(0.08);
-    expect(released.idleSpin).toBeGreaterThan(spinning.idleSpin);
-    expect(released.y).toBeGreaterThan(spinning.y);
+    expect(released.spinVelocityY).toBeLessThan(boosted.spinVelocityY);
+    expect(released.idleSpin).toBeGreaterThan(boosted.idleSpin + 1.4);
+    expect(released.y).toBeGreaterThan(boosted.y + 1.4);
   });
 });


### PR DESCRIPTION
## Summary
- add throw momentum to the homepage 3D coin so horizontal flicks keep it spinning after release
- decay flick velocity over time so it settles back into the normal idle coin spin
- keep the coin actually grabbed until pointer release instead of using the short drag idle timeout

## Tests
- `node --test tests/logo-branding.test.js`
- `npx playwright test --project=chromium-fold-closed tests/playwright/homepage-mobile.spec.js`

## Visual check
- local Playwright drag/flick confirmed `spinVelocityY` jumps after release, carries the coin through multiple rotations, and decays while manual tilt returns to zero.