### PR TITLE
Match header logo to homepage token

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
     .site-brand {
       display: inline-flex;
       align-items: center;
-      gap: 0.7rem;
+      gap: 0.78rem;
       color: #fff;
       text-decoration: none;
       font-family: 'Poppins', sans-serif;
@@ -149,9 +149,23 @@
       min-width: 0;
     }
 
-    header img {
-      height: 48px;
-      max-width: 150px;
+    .site-token-mark {
+      position: relative;
+      display: grid;
+      place-items: center;
+      width: clamp(48px, 7vw, 58px);
+      aspect-ratio: 1;
+      border-radius: 50%;
+      background:
+        radial-gradient(circle at 32% 24%, #45ffe3 0 10%, transparent 28%),
+        radial-gradient(circle at 48% 50%, #1768f2 0, #0f766e 54%, #07131f 100%);
+      border: 2px solid rgba(216, 255, 247, 0.9);
+      box-shadow:
+        inset -7px -8px 12px rgba(0, 0, 0, 0.3),
+        inset 5px 5px 12px rgba(255, 255, 255, 0.18),
+        0 12px 28px rgba(0, 0, 0, 0.26);
+      flex: 0 0 auto;
+      overflow: hidden;
       transform:
         translate3d(calc(var(--hero-tilt-x, 0) * 0.18px), calc(var(--hero-tilt-y, 0) * -0.18px), 0)
         rotate(calc(var(--hero-tilt-x, 0) * 0.06deg));
@@ -159,13 +173,56 @@
       will-change: transform;
     }
 
-    .site-logo {
-      display: block;
-      width: 44px;
-      height: 44px;
-      border-radius: 12px;
-      box-shadow: 0 12px 28px rgba(0, 0, 0, 0.22);
-      flex: 0 0 auto;
+    .site-token-mark::before,
+    .site-token-mark::after {
+      content: "";
+      position: absolute;
+      border-radius: 50%;
+      pointer-events: none;
+    }
+
+    .site-token-mark::before {
+      inset: 7px;
+      border: 2px solid rgba(254, 215, 170, 0.78);
+      box-shadow: inset 0 0 16px rgba(0, 0, 0, 0.24);
+    }
+
+    .site-token-mark::after {
+      inset: -14%;
+      background:
+        repeating-linear-gradient(
+          45deg,
+          rgba(255, 255, 255, 0.18) 0 3px,
+          transparent 3px 14px
+        );
+      opacity: 0.28;
+      mix-blend-mode: screen;
+    }
+
+    .site-token-mark__text {
+      position: relative;
+      z-index: 1;
+      display: grid;
+      place-items: center;
+      line-height: 0.9;
+      text-align: center;
+      text-shadow: 0 2px 8px rgba(0, 0, 0, 0.48);
+      transform: translateY(1px);
+    }
+
+    .site-token-mark__main {
+      color: #ffffff;
+      font-size: clamp(0.72rem, 2vw, 0.9rem);
+      font-weight: 900;
+      letter-spacing: -0.04em;
+    }
+
+    .site-token-mark__suffix {
+      margin-top: 0.1rem;
+      color: #ccfbf1;
+      font-size: clamp(0.42rem, 1.2vw, 0.55rem);
+      font-weight: 850;
+      letter-spacing: 0;
     }
 
     .site-brand__name {
@@ -1598,7 +1655,12 @@
   </div>
   <header>
     <a class="site-brand" href="#top" aria-label="3dvr.tech home">
-      <img class="site-logo" src="/assets/logo-3dvr.svg" alt="" />
+      <span class="site-token-mark" aria-hidden="true">
+        <span class="site-token-mark__text">
+          <span class="site-token-mark__main">3dvr</span>
+          <span class="site-token-mark__suffix">.tech</span>
+        </span>
+      </span>
       <span class="site-brand__name">3dvr<span>.tech</span></span>
     </a>
 

--- a/tests/logo-branding.test.js
+++ b/tests/logo-branding.test.js
@@ -11,6 +11,11 @@ describe('3dvr-web logo branding', () => {
     assert.match(logo, />3dvr</);
     assert.match(logo, />\.tech</);
     assert.match(html, /class="site-brand"[^>]+aria-label="3dvr\.tech home"/);
+    assert.match(html, /class="site-token-mark" aria-hidden="true"/);
+    assert.match(html, /class="site-token-mark__main">3dvr<\/span>/);
+    assert.match(html, /class="site-token-mark__suffix">\.tech<\/span>/);
+    assert.match(html, /\.site-token-mark::before/);
+    assert.match(html, /radial-gradient\(circle at 48% 50%, #1768f2 0, #0f766e 54%, #07131f 100%\)/);
     assert.match(html, /<span class="site-brand__name">3dvr<span>\.tech<\/span><\/span>/);
     assert.match(html, /<strong>3dvr<span>\.tech<\/span><\/strong>/);
     assert.match(html, /data-3dvr-token/);


### PR DESCRIPTION
## Summary
- replaces the top-left square SVG header icon with a circular 3dvr.tech token mark
- matches the hero spinning coin style with the same blue/teal gradient, light ring, warm inner ring, and token text
- keeps the readable `3dvr.tech` wordmark beside the mark

## Tests
- `node --test tests/logo-branding.test.js tests/homepage-growth.test.js tests/service-worker.test.js`
- `git diff --check`
- Playwright/Xvfb smoke check for desktop and mobile header sizing/containment