### PR TITLE
Improve web token front flips

### DIFF
--- a/homepage-logo-token.js
+++ b/homepage-logo-token.js
@@ -5,16 +5,19 @@
   const IDLE_WOBBLE_X = 0.025;
   const IDLE_WOBBLE_Z = 0.012;
   const DRAG_SPIN_FACTOR = 0.018;
-  const DRAG_VERTICAL_SPIN_FACTOR = DRAG_SPIN_FACTOR;
+  const DRAG_VERTICAL_SPIN_FACTOR = 0.034;
   const MAX_SPIN_MOMENTUM = 0.014;
-  const MAX_VERTICAL_SPIN_MOMENTUM = 0.0018;
+  const MAX_VERTICAL_SPIN_MOMENTUM = 0.032;
   const MIN_SPIN_MOMENTUM = 0.00008;
   const SPIN_MOMENTUM_DECAY = 0.992;
-  const VERTICAL_SPIN_MOMENTUM_DECAY = 0.9;
+  const VERTICAL_SPIN_MOMENTUM_DECAY = 0.986;
+  const ACTIVE_FRONT_FLIP_TARGET_RETURN = 0.018;
+  const FRONT_FLIP_SETTLE_VELOCITY = 0.0012;
   const MANUAL_X_TARGET_RETURN = 0.14;
   const MANUAL_X_CURRENT_RETURN = 0.24;
   const MANUAL_TARGET_RETURN = 0.1;
   const MANUAL_CURRENT_RETURN = 0.18;
+  const FULL_TURN = Math.PI * 2;
   const root = document.querySelector('[data-3dvr-token]');
   const canvas = document.querySelector('[data-3dvr-token-canvas]');
 
@@ -49,6 +52,23 @@
 
   function clamp(value, min, max) {
     return Math.min(max, Math.max(min, value));
+  }
+
+  function nearestFullTurn(value) {
+    return Math.round(value / FULL_TURN) * FULL_TURN;
+  }
+
+  function settleFrontFlipAxis() {
+    if (state.dragging || Math.abs(state.spinVelocityX) >= FRONT_FLIP_SETTLE_VELOCITY) return;
+    if (Math.abs(state.spinVelocityX) < FRONT_FLIP_SETTLE_VELOCITY) {
+      state.spinVelocityX = 0;
+    }
+
+    if (Math.abs(state.currentX) < FULL_TURN && Math.abs(state.targetX) < FULL_TURN) return;
+
+    const turnOffset = nearestFullTurn(state.currentX);
+    state.currentX -= turnOffset;
+    state.targetX = nearestFullTurn(state.currentX);
   }
 
   function loadThree() {
@@ -235,7 +255,12 @@
     updateIdleSpin(timestamp);
 
     if (!state.dragging) {
-      state.targetX += (state.restX - state.targetX) * MANUAL_X_TARGET_RETURN;
+      settleFrontFlipAxis();
+      const xTargetReturn =
+        Math.abs(state.spinVelocityX) >= FRONT_FLIP_SETTLE_VELOCITY
+          ? ACTIVE_FRONT_FLIP_TARGET_RETURN
+          : MANUAL_X_TARGET_RETURN;
+      state.targetX += (state.restX - state.targetX) * xTargetReturn;
       state.targetY += (state.restY - state.targetY) * MANUAL_TARGET_RETURN;
       state.targetZ += (state.restZ - state.targetZ) * MANUAL_TARGET_RETURN;
     }

--- a/tests/logo-branding.test.js
+++ b/tests/logo-branding.test.js
@@ -39,11 +39,14 @@ describe('3dvr-web logo branding', () => {
     assert.match(token, /IDLE_WOBBLE_X = 0\.025/);
     assert.match(token, /IDLE_WOBBLE_Z = 0\.012/);
     assert.match(token, /DRAG_SPIN_FACTOR = 0\.018/);
-    assert.match(token, /DRAG_VERTICAL_SPIN_FACTOR = DRAG_SPIN_FACTOR/);
+    assert.match(token, /DRAG_VERTICAL_SPIN_FACTOR = 0\.034/);
     assert.match(token, /MAX_SPIN_MOMENTUM = 0\.014/);
-    assert.match(token, /MAX_VERTICAL_SPIN_MOMENTUM = 0\.0018/);
+    assert.match(token, /MAX_VERTICAL_SPIN_MOMENTUM = 0\.032/);
     assert.match(token, /SPIN_MOMENTUM_DECAY = 0\.992/);
-    assert.match(token, /VERTICAL_SPIN_MOMENTUM_DECAY = 0\.9/);
+    assert.match(token, /VERTICAL_SPIN_MOMENTUM_DECAY = 0\.986/);
+    assert.match(token, /ACTIVE_FRONT_FLIP_TARGET_RETURN = 0\.018/);
+    assert.match(token, /FRONT_FLIP_SETTLE_VELOCITY = 0\.0012/);
+    assert.match(token, /FULL_TURN = Math\.PI \* 2/);
     assert.match(token, /MANUAL_X_TARGET_RETURN = 0\.14/);
     assert.match(token, /MANUAL_X_CURRENT_RETURN = 0\.24/);
     assert.match(token, /MANUAL_TARGET_RETURN = 0\.1/);
@@ -59,6 +62,8 @@ describe('3dvr-web logo branding', () => {
     assert.match(token, /spinVelocityY/);
     assert.match(token, /state\.idleSpin \+= elapsed \* \(IDLE_QUARTER_SPIN_SPEED \+ state\.spinVelocityY\)/);
     assert.match(token, /state\.targetX \+= elapsed \* state\.spinVelocityX/);
+    assert.match(token, /nearestFullTurn/);
+    assert.match(token, /settleFrontFlipAxis/);
     assert.match(token, /const verticalIntent = Math\.abs\(dy\) \/ Math\.max\(Math\.abs\(dx\), Math\.abs\(dy\), 1\)/);
     assert.match(token, /const verticalSpinDelta = dy \* DRAG_VERTICAL_SPIN_FACTOR \* verticalIntent/);
     assert.match(token, /state\.targetX \+= verticalSpinDelta/);
@@ -67,7 +72,8 @@ describe('3dvr-web logo branding', () => {
     assert.match(token, /pointerdown/);
     assert.match(token, /pointermove/);
     assert.match(token, /releasePointerCapture/);
-    assert.match(token, /state\.targetX \+= \(state\.restX - state\.targetX\) \* MANUAL_X_TARGET_RETURN/);
+    assert.match(token, /const xTargetReturn =/);
+    assert.match(token, /state\.targetX \+= \(state\.restX - state\.targetX\) \* xTargetReturn/);
     assert.match(token, /__3dvrLogoToken/);
   });
 });

--- a/tests/playwright/homepage-mobile.spec.js
+++ b/tests/playwright/homepage-mobile.spec.js
@@ -126,7 +126,7 @@ test.describe('homepage mobile sticky CTA', () => {
     expect(Math.abs(initial.manualY)).toBeLessThan(0.02);
     expect(Math.abs(initial.manualZ)).toBeLessThan(0.02);
     expect(spinning.idleSpin).toBeGreaterThan(initial.idleSpin + 0.06);
-    expect(spinning.y).toBeGreaterThan(initial.y + 0.25);
+    expect(spinning.y).toBeGreaterThan(initial.y + 0.2);
     expect(Math.abs(spinning.wobbleX)).toBeLessThan(0.026);
     expect(Math.abs(spinning.z - spinning.manualZ)).toBeLessThan(0.013);
 
@@ -152,5 +152,40 @@ test.describe('homepage mobile sticky CTA', () => {
     expect(released.spinVelocityY).toBeLessThan(boosted.spinVelocityY);
     expect(released.idleSpin).toBeGreaterThan(boosted.idleSpin + 1.4);
     expect(released.y).toBeGreaterThan(boosted.y + 1.4);
+  });
+
+  test('lets vertical token drags front-flip several times before settling', async ({ page }, testInfo) => {
+    test.skip(!isMobileProject(testInfo), 'Mobile-only homepage check');
+
+    await page.goto('/');
+    await page.waitForFunction(() => window.__3dvrLogoToken?.ready === true);
+    await page.waitForTimeout(300);
+
+    const token = page.locator('.hero-token');
+    const box = await token.boundingBox();
+    expect(box).not.toBeNull();
+
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2 - 190, { steps: 5 });
+    await page.mouse.up();
+    await page.waitForTimeout(180);
+
+    const released = await page.evaluate(() => window.__3dvrLogoToken.getRotation());
+    expect(Math.abs(released.spinVelocityX)).toBeGreaterThan(0.012);
+
+    await page.waitForTimeout(1200);
+
+    const flipping = await page.evaluate(() => window.__3dvrLogoToken.getRotation());
+    expect(Math.abs(flipping.x - released.x)).toBeGreaterThan(Math.PI * 1.25);
+    expect(Math.abs(flipping.spinVelocityX)).toBeGreaterThan(0.002);
+
+    await page.waitForFunction(() => Math.abs(window.__3dvrLogoToken.getRotation().spinVelocityX) === 0, null, {
+      timeout: 6500
+    });
+    await page.waitForTimeout(1200);
+
+    const settled = await page.evaluate(() => window.__3dvrLogoToken.getRotation());
+    expect(Math.abs(settled.manualX)).toBeLessThan(0.12);
   });
 });


### PR DESCRIPTION
## Summary
- make vertical drags on the 3dvr.tech homepage token build much stronger front-flip momentum
- slow the active X-axis return while the token is flipping, then settle back toward the nearest front-facing orientation
- add focused unit coverage and a mobile Playwright gesture check for repeated vertical flips before settling

## Validation
- `node --check homepage-logo-token.js`
- `node --test tests/logo-branding.test.js`
- `git diff --check`
- `npm ci`
- `npx playwright test tests/playwright/homepage-mobile.spec.js --project=chromium-fold-closed`

Note: I also tried `npm run test:unit -- tests/logo-branding.test.js`, but that script expands to the full `tests/*.test.js` suite and currently hits unrelated existing failures in `tests/life-plan.test.js` and `tests/vercel-insights-tag.test.js`.