### PR TITLE
[codex] Fix web health tests

### DIFF
--- a/3dvr-world/prize.html
+++ b/3dvr-world/prize.html
@@ -9,6 +9,7 @@
     content="The 3DVR World reward page with a fast path into the free starter plan, portal access, and a practical first build."
   />
   <link rel="stylesheet" href="styles.css" />
+  <script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body class="world-body world-prize-body world-ready">
   <main class="world-prize-route">

--- a/tests/life-plan.test.js
+++ b/tests/life-plan.test.js
@@ -7,7 +7,8 @@ test('free plan copy points to the portal start path in plain language', async (
   const plansHtml = await readFile(new URL('../subscribe/index.html', import.meta.url), 'utf8');
   const freeHtml = await readFile(new URL('../subscribe/free-plan.html', import.meta.url), 'utf8');
 
-  assert.match(homeHtml, /Choose one of three lanes: a daily check-in, a small support group, or direct help launching a project or offer\./);
+  assert.match(homeHtml, /Pick the lane that fits\./);
+  assert.match(homeHtml, /Light monthly support/);
   assert.match(plansHtml, /Get organized, sort out your next steps, and start using the portal without paying first\./);
   assert.match(plansHtml, /Daily check-ins and weekly reflection/);
   assert.match(plansHtml, /Start free to get organized/);


### PR DESCRIPTION
## Summary
- align the life-plan unit test with the current homepage plan dock copy
- add the missing Vercel Insights tag to the Builder Pass prize page

## Validation
- npm run test:unit