### PR TITLE
[codex] Move backpack before car on vision page

### DIFF
--- a/tests/vision-page.test.js
+++ b/tests/vision-page.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+test('vision page places the backpack before the car', async () => {
+  const html = await readFile(new URL('../vision/index.html', import.meta.url), 'utf8');
+
+  const backpackIndex = html.indexOf('id="backpack"');
+  const tentIndex = html.indexOf('id="tent"');
+  const carIndex = html.indexOf('id="car"');
+  const yurtIndex = html.indexOf('id="yurt"');
+
+  assert.match(html, /laptop, phone, e-bike, backpack, tent, car, and yurt/);
+  assert.ok(backpackIndex !== -1, 'Backpack product card should exist');
+  assert.ok(tentIndex !== -1, 'Tent product card should exist');
+  assert.ok(carIndex !== -1, 'Car product card should exist');
+  assert.ok(yurtIndex !== -1, 'Yurt product card should exist');
+  assert.ok(backpackIndex < carIndex, 'Backpack should appear before Car');
+  assert.ok(tentIndex < carIndex, 'Tent should appear before Car in the practical roadmap sequence');
+  assert.ok(carIndex < yurtIndex, 'Car should still appear before Yurt');
+
+  const backpackCreditIndex = html.indexOf('Backpack/Tent/Yurt');
+  const carCreditIndex = html.indexOf('Car/Micro-EV');
+  assert.ok(backpackCreditIndex !== -1, 'Backpack credits should exist');
+  assert.ok(carCreditIndex !== -1, 'Car credits should exist');
+  assert.ok(backpackCreditIndex < carCreditIndex, 'Backpack credits should appear before car credits');
+});

--- a/vision/index.html
+++ b/vision/index.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>3dvr.tech · Our Vision</title>
-  <meta name="description" content="3dvr.tech is building an open-source ecosystem: laptop, phone, e-bike, car, backpack, tent, and yurt — plus a suite of web apps and subscriptions to get there." />
+  <meta name="description" content="3dvr.tech is building an open-source ecosystem: laptop, phone, e-bike, backpack, tent, car, and yurt — plus a suite of web apps and subscriptions to get there." />
   <meta name="robots" content="index, follow" />
   <link rel="canonical" href="https://3dvr.tech/vision/" />
   <meta property="og:type" content="website" />
@@ -239,23 +239,6 @@
         </div>
       </article>
 
-      <!-- Car / Micro-EV -->
-      <article class="card two" id="car">
-        <div class="col">
-          <h3>Micro-EV / Car (later)</h3>
-          <p>Graduate from scooter/bike to a road-legal micro-EV inspired by the open TABBY EVO platform. Keep it modular and hackable for community fleets.</p>
-          <div class="links">
-            <a href="https://www.openmotors.co/product/tabbyevo/" target="_blank" rel="noopener">Open Motors · TABBY EVO →</a>
-            <a href="https://www.openmotors.co/download/" target="_blank" rel="noopener">Download TABBY designs →</a>
-          </div>
-          <div class="meta">Focus: low cost, easy maintenance, interchangeable modules.</div>
-        </div>
-        <div class="col">
-          <span class="pill">Chassis: modular</span>
-          <span class="pill">Telematics: open</span>
-        </div>
-      </article>
-
       <!-- Backpack -->
       <article class="card two" id="backpack">
         <div class="col">
@@ -285,6 +268,23 @@
         <div class="col">
           <span class="pill">Modular poles</span>
           <span class="pill">Repair patches</span>
+        </div>
+      </article>
+
+      <!-- Car / Micro-EV -->
+      <article class="card two" id="car">
+        <div class="col">
+          <h3>Micro-EV / Car (later)</h3>
+          <p>Graduate from scooter/bike to a road-legal micro-EV inspired by the open TABBY EVO platform. Keep it modular and hackable for community fleets.</p>
+          <div class="links">
+            <a href="https://www.openmotors.co/product/tabbyevo/" target="_blank" rel="noopener">Open Motors · TABBY EVO →</a>
+            <a href="https://www.openmotors.co/download/" target="_blank" rel="noopener">Download TABBY designs →</a>
+          </div>
+          <div class="meta">Focus: low cost, easy maintenance, interchangeable modules.</div>
+        </div>
+        <div class="col">
+          <span class="pill">Chassis: modular</span>
+          <span class="pill">Telematics: open</span>
         </div>
       </article>
 
@@ -338,8 +338,8 @@
         <li>Laptop: <a href="https://balthazar.space/" target="_blank" rel="noopener">Balthazar</a> · <a href="https://nlnet.nl/project/Balthazar-Prototype/" target="_blank" rel="noopener">NLnet</a></li>
         <li>Phone: <a href="https://ubuntu-touch.io/" target="_blank" rel="noopener">Ubuntu Touch</a> · <a href="https://postmarketos.org/" target="_blank" rel="noopener">postmarketOS</a> · <a href="https://pine64.org/devices/pinephone/" target="_blank" rel="noopener">PinePhone</a></li>
         <li>E-bike/Scooter: <a href="https://vesc-project.com/" target="_blank" rel="noopener">VESC project</a></li>
-        <li>Car/Micro-EV: <a href="https://www.openmotors.co/product/tabbyevo/" target="_blank" rel="noopener">Open Motors · TABBY EVO</a> (<a href="https://www.openmotors.co/download/" target="_blank" rel="noopener">downloads</a>)</li>
         <li>Backpack/Tent/Yurt: <a href="https://www.opensourceecology.org/" target="_blank" rel="noopener">Open Source Ecology</a> · <a href="https://www.openbuildinginstitute.org/" target="_blank" rel="noopener">Open Building Institute</a></li>
+        <li>Car/Micro-EV: <a href="https://www.openmotors.co/product/tabbyevo/" target="_blank" rel="noopener">Open Motors · TABBY EVO</a> (<a href="https://www.openmotors.co/download/" target="_blank" rel="noopener">downloads</a>)</li>
       </ul>
     </section>
 


### PR DESCRIPTION
## Summary
- Move the Backpack and Tent cards before the Car card on the public vision page
- Update the meta description and credit ordering to match the roadmap sequence
- Add a targeted Node test for the vision-page order

## Validation
- node --test tests/vision-page.test.js
- git diff --check