### PR TITLE
[codex] Tighten homepage hero

### DIFF
--- a/growth/homepage-experiment.js
+++ b/growth/homepage-experiment.js
@@ -7,14 +7,12 @@
 
   const VISITOR_ID_KEY = '3dvr-growth.visitor-id';
   const VARIANT_DAY_KEY = '3dvr-growth.homepage-hero.variant-day';
-  const FEEDBACK_DAY_KEY = '3dvr-growth.homepage-hero.feedback-day';
   const GUN_PEERS = window.__GUN_PEERS__ || [
     'wss://relay.3dvr.tech/gun',
     'wss://gun-relay-3dvr.fly.dev/gun',
   ];
   const EXPERIMENT_CONFIG_PATH = ['3dvr-portal', 'growth', 'experiments', 'homepage-hero', 'config'];
   const EXPERIMENT_EVENT_PATH = ['3dvr-portal', 'growth', 'experiments', 'homepage-hero', 'events'];
-  const FEEDBACK_EVENT_PATH = ['3dvr-portal', 'growth', 'feedback', 'homepage-hero'];
   const MIN_WEIGHT = 1;
   const DEFAULT_CONFIG = Object.freeze({
     autoMode: true,
@@ -27,17 +25,13 @@
       key: 'clarity',
       eyebrow: 'Websites. Apps. Direct support.',
       primary: 'We help small businesses actually launch.',
-      secondary: 'Not just plan. Not just think about it.',
-      body: 'Get a site, landing page, or simple business system with direct help from idea to launch.',
-      feedbackPrompt: 'Does this explain the offer clearly?',
+      body: 'Launch a site, offer, or simple business system with direct support from idea to live.',
     }),
     traction: Object.freeze({
       key: 'traction',
       eyebrow: 'Launch fast. Start selling.',
       primary: 'Get your project live.',
-      secondary: 'Keep it moving with direct support.',
       body: '3dvr helps small businesses and creators launch pages, apps, and follow-up systems without getting stuck in tech.',
-      feedbackPrompt: 'Does this version make you want to reach out?',
     }),
   });
 
@@ -45,11 +39,7 @@
     hero: document.querySelector('.hero'),
     eyebrow: document.getElementById('heroEyebrow'),
     headlinePrimary: document.getElementById('heroHeadlinePrimary'),
-    headlineSecondary: document.getElementById('heroHeadlineSecondary'),
     body: document.getElementById('heroBody'),
-    feedbackPrompt: document.getElementById('heroFeedbackPrompt'),
-    feedbackStatus: document.getElementById('heroFeedbackStatus'),
-    feedbackButtons: Array.from(document.querySelectorAll('[data-growth-feedback]')),
     ctaLinks: Array.from(document.querySelectorAll('[data-growth-cta]')),
   };
 
@@ -147,10 +137,6 @@
     return getNode(root, EXPERIMENT_EVENT_PATH);
   }
 
-  function feedbackNode(root) {
-    return getNode(root, FEEDBACK_EVENT_PATH);
-  }
-
   function applyVariant(variantKey) {
     const variant = VARIANTS[variantKey] || VARIANTS.clarity;
     state.variantKey = variant.key;
@@ -159,9 +145,7 @@
     }
     if (refs.eyebrow) refs.eyebrow.textContent = variant.eyebrow;
     if (refs.headlinePrimary) refs.headlinePrimary.textContent = variant.primary;
-    if (refs.headlineSecondary) refs.headlineSecondary.textContent = variant.secondary;
     if (refs.body) refs.body.textContent = variant.body;
-    if (refs.feedbackPrompt) refs.feedbackPrompt.textContent = variant.feedbackPrompt;
   }
 
   function writeEvent(root, pathResolver, payload) {
@@ -204,44 +188,10 @@
     });
   }
 
-  function submitFeedback(root, sentiment) {
-    const day = todayKey();
-    const previous = safeStorageGet(FEEDBACK_DAY_KEY);
-    if (previous === `${day}:${sentiment}:${state.variantKey}`) {
-      if (refs.feedbackStatus) {
-        refs.feedbackStatus.textContent = 'Feedback already saved for today.';
-      }
-      return;
-    }
-
-    safeStorageSet(FEEDBACK_DAY_KEY, `${day}:${sentiment}:${state.variantKey}`);
-    writeEvent(root, feedbackNode, {
-      visitorId: state.visitorId,
-      page: 'homepage',
-      sentiment,
-      variant: state.variantKey,
-      prompt: refs.feedbackPrompt?.textContent || '',
-      timestamp: new Date().toISOString(),
-      source: '3dvr-web',
-    });
-
-    if (refs.feedbackStatus) {
-      refs.feedbackStatus.textContent = sentiment === 'clear'
-        ? 'Saved. This version felt clear.'
-        : 'Saved. This version still felt vague.';
-    }
-  }
-
   function bindInteractions(root) {
     refs.ctaLinks.forEach(link => {
       link.addEventListener('click', () => {
         logCtaClick(root, String(link.dataset.growthCta || 'unknown').trim());
-      });
-    });
-
-    refs.feedbackButtons.forEach(button => {
-      button.addEventListener('click', () => {
-        submitFeedback(root, String(button.dataset.growthFeedback || 'clear').trim());
       });
     });
   }
@@ -257,9 +207,6 @@
     bindInteractions(root);
 
     if (!gun) {
-      if (refs.feedbackStatus) {
-        refs.feedbackStatus.textContent = 'Feedback works best when Gun is available.';
-      }
       return;
     }
 
@@ -272,9 +219,6 @@
       state.config = normalizeConfig(data);
       applyVariant(chooseVariant(state.config, state.visitorId));
       logView(root);
-      if (refs.feedbackStatus && state.config.autoMode && state.config.winner) {
-        refs.feedbackStatus.textContent = `Live winner: ${state.config.winner}.`;
-      }
     });
   }
 

--- a/index.html
+++ b/index.html
@@ -513,21 +513,11 @@
       line-height: 1.1;
     }
     .hero-headline {
-      display: inline-flex;
-      flex-direction: column;
-      align-items: center;
-      gap: clamp(0.6rem, 1.5vw, 1rem);
-    }
-    .hero-headline-primary,
-    .hero-headline-secondary {
       display: block;
+      max-width: 900px;
     }
-    .hero-headline-divider {
-      width: clamp(60px, 14vw, 120px);
-      height: 4px;
-      border-radius: 999px;
-      background: linear-gradient(90deg, rgba(0,255,200,0.85), rgba(255,255,255,0.8));
-      box-shadow: 0 6px 20px rgba(0, 255, 200, 0.35);
+    .hero-headline-primary {
+      display: block;
     }
     .hero p {
       font-size: clamp(1.1rem, 2vw, 1.4rem);
@@ -540,96 +530,40 @@
       gap: 1rem;
       justify-content: center;
     }
-    .hero-route-guide {
-      width: min(100%, 760px);
+    .plan-lane-section {
+      padding-block: clamp(3rem, 6vw, 5rem);
+      background:
+        radial-gradient(circle at 18% 12%, rgba(0, 255, 200, 0.18), transparent 38rem),
+        linear-gradient(160deg, rgba(12, 33, 45, 0.96), rgba(19, 71, 78, 0.96));
+    }
+    .plan-lane-dock {
       display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: 0.9rem;
-      padding: 1rem;
-      border-radius: 20px;
-      background: rgba(0, 0, 0, 0.28);
-      border: 1px solid rgba(255, 255, 255, 0.1);
-      box-shadow: 0 12px 24px rgba(0, 0, 0, 0.18);
+      width: min(100%, 900px);
     }
-    .hero-route {
-      display: grid;
-      gap: 0.35rem;
-      padding: 0.9rem 1rem;
-      border-radius: 16px;
-      background: rgba(255, 255, 255, 0.08);
-      border: 1px solid rgba(255, 255, 255, 0.12);
-      text-align: left;
+    .plan-lane-title {
+      margin: 0;
+      font-size: clamp(1.5rem, 4vw, 2.4rem);
     }
-    .hero-route strong {
-      font-size: 1rem;
-      color: var(--accent);
-    }
-    .hero-route span {
-      font-size: 0.92rem;
-      color: rgba(255, 255, 255, 0.8);
-      line-height: 1.45;
-    }
-    .hero-feedback {
-      width: min(100%, 760px);
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
-      justify-content: center;
-      gap: 0.75rem;
-      padding: 0.95rem 1rem;
-      border-radius: 18px;
-      background: rgba(0,0,0,0.28);
-      border: 1px solid rgba(255,255,255,0.1);
-      box-shadow: 0 12px 24px rgba(0,0,0,0.18);
-    }
-    .hero-feedback__prompt {
-      font-size: 0.92rem;
-      color: rgba(255,255,255,0.84);
-      font-weight: 600;
-    }
-    .hero-feedback__buttons {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.65rem;
-      justify-content: center;
-    }
-    .hero-feedback__button {
-      border: 1px solid rgba(255,255,255,0.18);
-      background: rgba(255,255,255,0.1);
-      color: var(--text-light);
-      border-radius: 999px;
-      padding: 0.55rem 1rem;
-      font: inherit;
-      font-weight: 600;
-      cursor: pointer;
-      transition: transform 0.25s ease, background 0.25s ease;
-    }
-    .hero-feedback__button:hover {
-      transform: translateY(-2px);
-      background: rgba(255,255,255,0.16);
-    }
-    .hero-feedback__status {
-      font-size: 0.82rem;
-      color: rgba(255,255,255,0.66);
-    }
-    .hero-plan-dock {
-      display: grid;
-      gap: 0.85rem;
-      width: min(100%, 760px);
-    }
-    .hero-plan-dock__label {
+    .plan-lane-dock__label {
       font-size: 0.82rem;
       letter-spacing: 0.16em;
       text-transform: uppercase;
       color: rgba(255,255,255,0.72);
     }
-    .hero-plan-dock__grid {
+    .plan-lane-dock__intro {
+      margin: 0 auto 0.4rem;
+      max-width: 640px;
+      color: rgba(255,255,255,0.78);
+      font-size: clamp(1rem, 1.8vw, 1.18rem);
+    }
+    .plan-lane-dock__grid {
       display: grid;
       grid-template-columns: repeat(3, minmax(0, 1fr));
       gap: 0.8rem;
       width: 100%;
     }
-    .hero-plan-chip {
+    .plan-lane-chip {
       display: grid;
       gap: 0.3rem;
       padding: 0.95rem 1rem;
@@ -642,16 +576,16 @@
       transition: transform 0.3s ease, background 0.3s ease, border-color 0.3s ease;
       box-shadow: 0 12px 28px rgba(0,0,0,0.2);
     }
-    .hero-plan-chip:hover {
+    .plan-lane-chip:hover {
       transform: translateY(-3px);
       background: rgba(255,255,255,0.14);
       border-color: rgba(0,255,200,0.35);
     }
-    .hero-plan-chip strong {
+    .plan-lane-chip strong {
       font-size: 1rem;
       color: var(--accent);
     }
-    .hero-plan-chip span {
+    .plan-lane-chip span {
       font-size: 0.82rem;
       color: rgba(255,255,255,0.78);
     }
@@ -921,10 +855,10 @@
       .hero-intro { text-align: center; margin-bottom: 0; align-self: center; }
       .hero-content { text-align: center; align-items: center; margin-top: 0; }
       .hero p { max-width: none; }
-      .hero-plan-dock__grid {
+      .plan-lane-dock__grid {
         grid-template-columns: repeat(2, minmax(0, 1fr));
       }
-      .hero-plan-dock__grid > :last-child:nth-child(odd) {
+      .plan-lane-dock__grid > :last-child:nth-child(odd) {
         grid-column: 1 / -1;
         justify-self: center;
         width: min(100%, calc(50% - 0.4rem));
@@ -1724,92 +1658,89 @@
       <div class="hero-content">
         <h1 class="hero-headline">
           <span id="heroHeadlinePrimary" class="hero-headline-primary">We help small businesses actually launch.</span>
-          <span class="hero-headline-divider" aria-hidden="true"></span>
-          <span id="heroHeadlineSecondary" class="hero-headline-secondary">Not just plan. Not just think about it.</span>
         </h1>
         <p id="heroBody">
-          Get a site, landing page, or simple business system with direct help from idea to launch.
+          Launch a site, offer, or simple business system with direct support from idea to live.
         </p>
         <div class="hero-buttons">
           <a
             class="hero-button hero-button--primary"
-            data-growth-cta="start-free-primary"
-            data-portal-path="/free-trial.html"
-            href="https://portal.3dvr.tech/free-trial.html"
+            data-growth-cta="start-project-primary"
+            data-portal-path="/start/"
+            href="https://portal.3dvr.tech/start/"
           >
-            Start free in portal
+            Start a project
           </a>
           <a class="hero-button hero-button--ghost" data-growth-cta="see-plans" href="#subscribe">
             See plans
           </a>
         </div>
-        <div class="hero-feedback" aria-label="Homepage clarity feedback">
-          <span id="heroFeedbackPrompt" class="hero-feedback__prompt">Does this explain the offer clearly?</span>
-          <div class="hero-feedback__buttons">
-            <button type="button" class="hero-feedback__button" data-growth-feedback="clear">Yes, clear</button>
-            <button type="button" class="hero-feedback__button" data-growth-feedback="unclear">Still vague</button>
-          </div>
-          <span id="heroFeedbackStatus" class="hero-feedback__status">Anonymous feedback helps tune the homepage.</span>
-        </div>
-        <div class="hero-plan-dock" aria-label="Quick plan links">
-          <span class="hero-plan-dock__label">Pick the lane that fits.</span>
-          <div class="hero-plan-dock__grid">
-            <a
-              class="hero-plan-chip"
-              data-growth-cta="plan-free"
-              data-portal-path="/free-trial.html"
-              href="https://portal.3dvr.tech/free-trial.html"
-            >
-              <strong>Free</strong>
-              <span>Get organized first</span>
-            </a>
-            <a
-              class="hero-plan-chip"
-              data-growth-cta="plan-starter"
-              data-portal-path="/billing/?plan=starter"
-              href="https://portal.3dvr.tech/billing/?plan=starter"
-            >
-              <strong>$5</strong>
-              <span>Light monthly support</span>
-            </a>
-            <a
-              class="hero-plan-chip"
-              data-growth-cta="plan-20"
-              data-portal-path="/billing/?plan=pro"
-              href="https://portal.3dvr.tech/billing/?plan=pro"
-            >
-              <strong>$20</strong>
-              <span>Launch in 3 Days</span>
-            </a>
-            <a
-              class="hero-plan-chip"
-              data-growth-cta="plan-50"
-              data-portal-path="/billing/?plan=builder"
-              href="https://portal.3dvr.tech/billing/?plan=builder"
-            >
-              <strong>$50</strong>
-              <span>Default for businesses</span>
-            </a>
-            <a
-              class="hero-plan-chip"
-              data-growth-cta="plan-200"
-              data-portal-path="/billing/?plan=embedded"
-              href="https://portal.3dvr.tech/billing/?plan=embedded"
-            >
-              <strong>$200</strong>
-              <span>Run one calmer team system</span>
-            </a>
-            <a
-              class="hero-plan-chip"
-              data-growth-cta="plan-custom"
-              data-portal-path="/billing/?plan=custom"
-              href="https://portal.3dvr.tech/billing/?plan=custom"
-            >
-              <strong>Custom</strong>
-              <span>One-time payment or deposit</span>
-            </a>
-          </div>
-        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="plan-lane-section" aria-labelledby="planLaneTitle">
+    <div class="plan-lane-dock" aria-label="Quick plan links">
+      <span class="plan-lane-dock__label">Plans after the offer is clear</span>
+      <h2 id="planLaneTitle" class="plan-lane-title">Pick the lane that fits.</h2>
+      <p class="plan-lane-dock__intro">
+        Start free if you are still organizing, or choose the lane that matches the support you need.
+      </p>
+      <div class="plan-lane-dock__grid">
+        <a
+          class="plan-lane-chip"
+          data-growth-cta="plan-free"
+          data-portal-path="/free-trial.html"
+          href="https://portal.3dvr.tech/free-trial.html"
+        >
+          <strong>Free</strong>
+          <span>Get organized first</span>
+        </a>
+        <a
+          class="plan-lane-chip"
+          data-growth-cta="plan-starter"
+          data-portal-path="/billing/?plan=starter"
+          href="https://portal.3dvr.tech/billing/?plan=starter"
+        >
+          <strong>$5</strong>
+          <span>Light monthly support</span>
+        </a>
+        <a
+          class="plan-lane-chip"
+          data-growth-cta="plan-20"
+          data-portal-path="/billing/?plan=pro"
+          href="https://portal.3dvr.tech/billing/?plan=pro"
+        >
+          <strong>$20</strong>
+          <span>Launch in 3 Days</span>
+        </a>
+        <a
+          class="plan-lane-chip"
+          data-growth-cta="plan-50"
+          data-portal-path="/billing/?plan=builder"
+          href="https://portal.3dvr.tech/billing/?plan=builder"
+        >
+          <strong>$50</strong>
+          <span>Default for businesses</span>
+        </a>
+        <a
+          class="plan-lane-chip"
+          data-growth-cta="plan-200"
+          data-portal-path="/billing/?plan=embedded"
+          href="https://portal.3dvr.tech/billing/?plan=embedded"
+        >
+          <strong>$200</strong>
+          <span>Run one calmer team system</span>
+        </a>
+        <a
+          class="plan-lane-chip"
+          data-growth-cta="plan-custom"
+          data-portal-path="/billing/?plan=custom"
+          href="https://portal.3dvr.tech/billing/?plan=custom"
+        >
+          <strong>Custom</strong>
+          <span>One-time payment or deposit</span>
+        </a>
       </div>
     </div>
   </section>

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -5,19 +5,25 @@ import { readFile } from 'node:fs/promises';
 describe('3dvr-web customer journey copy', () => {
   it('keeps the homepage focused on concrete first steps and the portal start path', async () => {
     const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+    const heroHtml = html.match(/<section class="hero">[\s\S]*?<\/section>/)?.[0] || '';
+    const heroIndex = html.indexOf('<section class="hero">');
+    const planLaneIndex = html.indexOf('<section class="plan-lane-section"');
+    const whatWeDoIndex = html.indexOf('<section id="vision"');
+
     assert.match(html, /Websites\. Apps\. Direct support\./);
     assert.match(html, /We help small businesses actually launch\./);
-    assert.match(html, /Not just plan\. Not just think about it\./);
-    assert.match(html, /Get a site, landing page, or simple business system with direct help from idea to launch\./);
+    assert.match(html, /Launch a site, offer, or simple business system with direct support from idea to live\./);
     assert.match(html, /Start Free/);
-    assert.match(html, /Start free in portal/);
+    assert.match(html, /Start a project/);
     assert.match(html, /Launch in 3 Days/);
     assert.match(html, /A clear place to land when you need a site, support, or a launch plan\./);
+    assert.match(html, /data-portal-path="\/start\/"/);
     assert.match(html, /data-portal-path="\/free-trial\.html"/);
     assert.match(html, /data-portal-path="\/billing\/\?plan=starter"/);
     assert.match(html, /data-portal-path="\/billing\/\?plan=pro"/);
     assert.match(html, /data-portal-path="\/billing\/\?plan=builder"/);
     assert.match(html, /data-portal-path="\/billing\/\?plan=embedded"/);
+    assert.match(html, /Plans after the offer is clear/);
     assert.match(html, /Pick the lane that fits\./);
     assert.match(html, /Get organized first/);
     assert.match(html, /Light monthly support/);
@@ -69,6 +75,19 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /Trusted by friends, family, and small businesses/);
     assert.match(html, /See plans/);
     assert.match(html, /hero-logo-card/);
+    assert.ok(heroIndex !== -1, 'Hero section should exist');
+    assert.ok(planLaneIndex !== -1, 'Plan lane section should exist');
+    assert.ok(whatWeDoIndex !== -1, 'What We Do section should exist');
+    assert.ok(heroIndex < planLaneIndex, 'Plan lane should move below the hero');
+    assert.ok(planLaneIndex < whatWeDoIndex, 'Plan lane should sit before What We Do');
+    assert.doesNotMatch(heroHtml, /plan-lane-section/);
+    assert.doesNotMatch(heroHtml, /Pick the lane that fits\./);
+    assert.doesNotMatch(heroHtml, /data-growth-cta="plan-free"/);
+    assert.doesNotMatch(heroHtml, /data-growth-feedback=/);
+    assert.doesNotMatch(html, /Does this explain the offer clearly\?/);
+    assert.doesNotMatch(html, /Still vague/);
+    assert.doesNotMatch(html, /Start free in portal/);
+    assert.doesNotMatch(html, /Not just plan\. Not just think about it\./);
     assert.doesNotMatch(html, /Open the full-screen 3DVR world prototype/);
     assert.match(html, /Nomad system direction/);
     assert.match(html, /Portable work, open hardware, and a calmer way to build on the move\./);

--- a/tests/homepage-growth.test.js
+++ b/tests/homepage-growth.test.js
@@ -2,29 +2,29 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
-test('homepage ships Gun-backed experiment and feedback plumbing', async () => {
+test('homepage ships Gun-backed experiment and focused CTA plumbing', async () => {
   const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
   const js = await readFile(new URL('../growth/homepage-experiment.js', import.meta.url), 'utf8');
 
   assert.match(html, /id="heroEyebrow"/);
   assert.match(html, /id="heroHeadlinePrimary"/);
-  assert.match(html, /id="heroHeadlineSecondary"/);
   assert.match(html, /id="heroBody"/);
-  assert.match(html, /id="heroFeedbackPrompt"/);
-  assert.match(html, /id="heroFeedbackStatus"/);
-  assert.match(html, /data-growth-feedback="clear"/);
-  assert.match(html, /data-growth-feedback="unclear"/);
+  assert.doesNotMatch(html, /id="heroHeadlineSecondary"/);
+  assert.doesNotMatch(html, /id="heroFeedbackPrompt"/);
+  assert.doesNotMatch(html, /id="heroFeedbackStatus"/);
+  assert.doesNotMatch(html, /data-growth-feedback=/);
   assert.match(html, /data-growth-cta="sticky-start-free"/);
-  assert.match(html, /data-growth-cta="start-free-primary"/);
+  assert.match(html, /data-growth-cta="start-project-primary"/);
   assert.match(html, /data-growth-cta="see-plans"/);
   assert.match(html, /class="hero-logo-card(?:\s|")/);
   assert.match(html, /A clear place to land when you need a site, support, or a launch plan\./);
   assert.doesNotMatch(html, /data-growth-cta="enter-3dvr-world"/);
+  assert.match(html, /class="plan-lane-section"/);
   assert.match(html, /data-growth-cta="plan-free"/);
   assert.match(html, /data-growth-cta="plan-starter"/);
   assert.match(html, /grid-template-columns:\s*repeat\(3,\s*minmax\(0,\s*1fr\)\)/);
   assert.match(html, /data-growth-cta="sticky-start-free"[^>]+data-portal-path="\/free-trial\.html"/);
-  assert.match(html, /data-growth-cta="start-free-primary"[^>]+data-portal-path="\/free-trial\.html"/);
+  assert.match(html, /data-growth-cta="start-project-primary"[^>]+data-portal-path="\/start\/"/);
   assert.match(html, /data-growth-cta="plan-free"[^>]+data-portal-path="\/free-trial\.html"/);
   assert.match(html, /data-growth-cta="plan-starter"[^>]+data-portal-path="\/billing\/\?plan=starter"/);
   assert.match(html, /data-growth-cta="plan-20"[^>]+data-portal-path="\/billing\/\?plan=pro"/);
@@ -50,13 +50,12 @@ test('homepage ships Gun-backed experiment and feedback plumbing', async () => {
 
   assert.match(js, /EXPERIMENT_CONFIG_PATH = \['3dvr-portal', 'growth', 'experiments', 'homepage-hero', 'config'\]/);
   assert.match(js, /EXPERIMENT_EVENT_PATH = \['3dvr-portal', 'growth', 'experiments', 'homepage-hero', 'events'\]/);
-  assert.match(js, /FEEDBACK_EVENT_PATH = \['3dvr-portal', 'growth', 'feedback', 'homepage-hero'\]/);
   assert.match(js, /eyebrow: 'Launch fast\. Start selling\.'/);
   assert.match(js, /primary: 'Get your project live\.'/);
-  assert.match(js, /secondary: 'Keep it moving with direct support\.'/);
   assert.match(js, /function chooseVariant/);
   assert.match(js, /function applyVariant/);
   assert.match(js, /function logView/);
   assert.match(js, /function logCtaClick/);
-  assert.match(js, /function submitFeedback/);
+  assert.doesNotMatch(js, /FEEDBACK_EVENT_PATH/);
+  assert.doesNotMatch(js, /function submitFeedback/);
 });

--- a/tests/playwright/homepage-mobile.spec.js
+++ b/tests/playwright/homepage-mobile.spec.js
@@ -32,14 +32,14 @@ test.describe('homepage mobile sticky CTA', () => {
     await expect(stickyCta).toBeVisible();
   });
 
-  test('keeps hero plan chips inside the mobile grid', async ({ page }, testInfo) => {
+  test('keeps plan lane chips inside the mobile grid', async ({ page }, testInfo) => {
     test.skip(!isMobileProject(testInfo), 'Mobile-only homepage check');
 
     await page.goto('/');
 
     const layout = await page.evaluate(() => {
-      const grid = document.querySelector('.hero-plan-dock__grid');
-      const chips = Array.from(document.querySelectorAll('.hero-plan-chip'));
+      const grid = document.querySelector('.plan-lane-dock__grid');
+      const chips = Array.from(document.querySelectorAll('.plan-lane-chip'));
 
       if (!grid || chips.length === 0) {
         return null;


### PR DESCRIPTION
## Summary
- Simplify the homepage hero to one clear offer, one supporting sentence, and two CTAs
- Remove the public hero clarity feedback widget and its unused Gun feedback plumbing
- Move the plan chips into a separate plan lane below the hero, with updated mobile selectors/tests

## Why
This is the first piece from `site-critique.md`: make the first viewport focus on the commercial offer before asking visitors to parse plans or feedback controls.

## Validation
- node --test tests/*.test.js
- git diff --check
- curl -fsSLI https://portal.3dvr.tech/start/ returned 200

## Not run
- npm run test:e2e:chromium could not run locally because `scripts/playwright/run-in-linux.sh` requires `proot-distro`, which is not installed in this shell.
