### PR TITLE
Add 3DVR plans ladder page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1615,7 +1615,7 @@
       <a href="subscribe/index.html">Start Free</a>
       <a href="#vision">What We Do</a>
       <a href="#system">System</a>
-      <a href="#subscribe">Plans</a>
+      <a href="plans/">Plans</a>
       <a href="#testimonials">Trust</a>
       <a href="https://portal.3dvr.tech">Portal</a>
     </nav>
@@ -1671,7 +1671,7 @@
           >
             Start a project
           </a>
-          <a class="hero-button hero-button--ghost" data-growth-cta="see-plans" href="#subscribe">
+          <a class="hero-button hero-button--ghost" data-growth-cta="see-plans" href="plans/">
             See plans
           </a>
         </div>
@@ -1837,6 +1837,9 @@
 
   <section id="subscribe" style="background: var(--bg-subscribe);">
     <h2>Simple ways to work together</h2>
+    <p class="section-lede">
+      Need the full ladder with one-time services? <a href="plans/">Open plans and project sprints</a>.
+    </p>
     <div class="card-grid">
       <a
         class="card"

--- a/plans/index.html
+++ b/plans/index.html
@@ -1,0 +1,734 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="manifest" href="/manifest.webmanifest" />
+  <meta name="theme-color" content="#0b1118" />
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="color-scheme" content="dark light" />
+  <meta
+    name="description"
+    content="Join 3DVR monthly or hire 3DVR for one-time website, AI workflow, microsite, and creative technology sprints."
+  />
+  <meta name="robots" content="index, follow" />
+  <link rel="canonical" href="https://3dvr.tech/plans/" />
+  <title>3DVR Plans and Project Sprints | 3dvr.tech</title>
+  <link rel="icon" href="../3DVRfavicon.png" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&family=Poppins:wght@600;700;800&display=swap" rel="stylesheet" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="3dvr.tech" />
+  <meta property="og:title" content="3DVR Plans and Project Sprints" />
+  <meta
+    property="og:description"
+    content="Support the 3DVR mission monthly, get help building your project, or start with a focused microsite sprint."
+  />
+  <meta property="og:url" content="https://3dvr.tech/plans/" />
+  <meta property="og:image" content="https://3dvr.tech/3DVR.png" />
+  <meta property="og:image:alt" content="3dvr.tech logomark" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="3DVR Plans and Project Sprints" />
+  <meta
+    name="twitter:description"
+    content="Join monthly, support the mission, or hire 3DVR for a one-time website, microsite, or creative tech sprint."
+  />
+  <meta name="twitter:image" content="https://3dvr.tech/3DVR.png" />
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Service",
+      "@id": "https://3dvr.tech/plans/#service",
+      "name": "3DVR plans and microsite services",
+      "provider": {
+        "@type": "Organization",
+        "@id": "https://3dvr.tech/#organization",
+        "name": "3dvr.tech",
+        "url": "https://3dvr.tech/"
+      },
+      "serviceType": "Web design, AI workflow, creative technology, and microsite services",
+      "areaServed": "US",
+      "url": "https://3dvr.tech/plans/"
+    }
+  </script>
+  <style>
+    :root {
+      --accent: #00ffc8;
+      --accent-2: #fed7aa;
+      --bg: #07111f;
+      --bg-soft: #0f2027;
+      --panel: rgba(255, 255, 255, 0.08);
+      --panel-strong: rgba(255, 255, 255, 0.13);
+      --border: rgba(255, 255, 255, 0.14);
+      --text: #ffffff;
+      --muted: #d7e0e7;
+      --dark: #00110d;
+      --shadow: 0 26px 70px rgba(0, 0, 0, 0.28);
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    html {
+      scroll-behavior: smooth;
+      background: var(--bg);
+    }
+
+    body {
+      min-height: 100vh;
+      color: var(--text);
+      font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background:
+        linear-gradient(rgba(7, 17, 31, 0.86), rgba(7, 17, 31, 0.9)),
+        url("../3DVR.png") center 5.2rem / min(92vw, 780px) auto no-repeat,
+        radial-gradient(circle at 14% 8%, rgba(0, 255, 200, 0.24), transparent 34rem),
+        radial-gradient(circle at 85% 15%, rgba(254, 215, 170, 0.22), transparent 28rem),
+        linear-gradient(160deg, #07111f, #0f2027 54%, #1f3d45);
+      line-height: 1.6;
+    }
+
+    a {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    header {
+      position: sticky;
+      top: 0;
+      z-index: 20;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      padding: 1rem 1.25rem;
+      background: rgba(0, 0, 0, 0.58);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+      backdrop-filter: blur(12px);
+    }
+
+    header img {
+      display: block;
+      height: 42px;
+      width: auto;
+    }
+
+    nav {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      gap: clamp(0.6rem, 1.8vw, 1.2rem);
+      flex-wrap: wrap;
+    }
+
+    nav a {
+      color: rgba(255, 255, 255, 0.9);
+      font-weight: 700;
+      font-size: 0.95rem;
+    }
+
+    nav a:hover,
+    nav a:focus-visible {
+      color: var(--accent);
+      outline: none;
+    }
+
+    main {
+      width: min(1180px, 100%);
+      margin: 0 auto;
+      padding: 0 1rem 4rem;
+    }
+
+    .hero {
+      min-height: calc(100vh - 74px);
+      display: grid;
+      align-content: center;
+      justify-items: center;
+      text-align: center;
+      padding: clamp(4rem, 9vw, 7rem) 0 clamp(2.5rem, 5vw, 4rem);
+    }
+
+    .eyebrow {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: fit-content;
+      padding: 0.45rem 0.85rem;
+      border-radius: 999px;
+      border: 1px solid rgba(0, 255, 200, 0.28);
+      background: rgba(0, 255, 200, 0.09);
+      color: #ccfbf1;
+      font-size: 0.78rem;
+      font-weight: 800;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+    }
+
+    h1,
+    h2,
+    h3 {
+      font-family: Poppins, Inter, sans-serif;
+      line-height: 1.04;
+    }
+
+    h1 {
+      max-width: 940px;
+      margin: 1.2rem auto 0;
+      font-size: clamp(3.2rem, 8vw, 6.8rem);
+      letter-spacing: -0.06em;
+    }
+
+    .hero p {
+      max-width: 810px;
+      margin: 1.2rem auto 0;
+      color: rgba(255, 255, 255, 0.84);
+      font-size: clamp(1.08rem, 2.2vw, 1.34rem);
+    }
+
+    .hero-actions,
+    .actions {
+      display: flex;
+      justify-content: center;
+      gap: 0.8rem;
+      flex-wrap: wrap;
+    }
+
+    .hero-actions {
+      margin-top: 2rem;
+    }
+
+    .cta {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 48px;
+      padding: 0.78rem 1.25rem;
+      border-radius: 999px;
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      background: rgba(255, 255, 255, 0.08);
+      color: var(--text);
+      font-weight: 800;
+      transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+    }
+
+    .cta.primary {
+      background: var(--accent);
+      border-color: transparent;
+      color: var(--dark);
+      box-shadow: 0 0 26px rgba(0, 255, 200, 0.32);
+    }
+
+    .cta.secondary {
+      background: rgba(0, 0, 0, 0.34);
+    }
+
+    .cta:hover,
+    .cta:focus-visible {
+      transform: translateY(-2px);
+      border-color: rgba(0, 255, 200, 0.55);
+      outline: none;
+    }
+
+    .section {
+      padding: clamp(3rem, 6vw, 5rem) 0;
+    }
+
+    .section-heading {
+      max-width: 760px;
+      margin-bottom: 1.5rem;
+    }
+
+    .section-heading.center {
+      margin-inline: auto;
+      text-align: center;
+    }
+
+    .section-heading h2 {
+      margin-top: 0.75rem;
+      font-size: clamp(2rem, 5vw, 4rem);
+      letter-spacing: -0.045em;
+    }
+
+    .section-heading p {
+      margin-top: 0.85rem;
+      color: var(--muted);
+      font-size: 1.08rem;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      gap: 1rem;
+    }
+
+    .plan-grid {
+      grid-template-columns: repeat(auto-fit, minmax(218px, 1fr));
+    }
+
+    .card {
+      display: flex;
+      flex-direction: column;
+      min-height: 100%;
+      padding: 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      background: var(--panel);
+      box-shadow: var(--shadow);
+    }
+
+    .card.featured {
+      border-color: rgba(0, 255, 200, 0.58);
+      background:
+        linear-gradient(150deg, rgba(0, 255, 200, 0.16), rgba(255, 255, 255, 0.09)),
+        var(--panel);
+    }
+
+    .card-label {
+      color: var(--accent);
+      font-size: 0.76rem;
+      font-weight: 800;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+    }
+
+    .card h3 {
+      margin-top: 0.65rem;
+      font-size: 1.2rem;
+    }
+
+    .price {
+      margin-top: 0.55rem;
+      color: var(--accent-2);
+      font-size: 1.9rem;
+      font-weight: 900;
+      letter-spacing: -0.03em;
+    }
+
+    .card p {
+      margin-top: 0.75rem;
+      color: var(--muted);
+    }
+
+    .card ul {
+      margin: 1rem 0 0 1rem;
+      color: rgba(255, 255, 255, 0.84);
+    }
+
+    .card li {
+      margin: 0.45rem 0;
+    }
+
+    .card .actions {
+      justify-content: flex-start;
+      margin-top: auto;
+      padding-top: 1.15rem;
+    }
+
+    .note {
+      margin-top: 0.8rem;
+      color: rgba(255, 255, 255, 0.68);
+      font-size: 0.9rem;
+    }
+
+    .split {
+      display: grid;
+      grid-template-columns: minmax(0, 0.88fr) minmax(0, 1.12fr);
+      gap: 1rem;
+      align-items: stretch;
+    }
+
+    .panel {
+      padding: clamp(1.35rem, 3vw, 2rem);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      background: rgba(255, 255, 255, 0.08);
+      box-shadow: var(--shadow);
+    }
+
+    .panel h2 {
+      font-size: clamp(1.65rem, 4vw, 2.8rem);
+      letter-spacing: -0.04em;
+    }
+
+    .panel p,
+    .panel li {
+      color: var(--muted);
+    }
+
+    .panel ul,
+    .panel ol {
+      margin: 1rem 0 0 1.15rem;
+    }
+
+    .panel li {
+      margin: 0.55rem 0;
+    }
+
+    .flow {
+      display: grid;
+      gap: 0.8rem;
+    }
+
+    .flow-step {
+      padding: 1rem;
+      border-radius: 14px;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      background: rgba(0, 0, 0, 0.24);
+    }
+
+    .flow-step strong {
+      display: block;
+      color: var(--accent);
+      margin-bottom: 0.35rem;
+    }
+
+    .footer-cta {
+      margin-top: 1rem;
+      padding: clamp(1.6rem, 4vw, 2.4rem);
+      border-radius: 22px;
+      border: 1px solid rgba(0, 255, 200, 0.28);
+      background:
+        linear-gradient(145deg, rgba(0, 255, 200, 0.13), rgba(254, 215, 170, 0.11)),
+        rgba(0, 0, 0, 0.24);
+      text-align: center;
+      box-shadow: var(--shadow);
+    }
+
+    .footer-cta h2 {
+      font-size: clamp(2rem, 5vw, 4rem);
+      letter-spacing: -0.05em;
+    }
+
+    .footer-cta p {
+      max-width: 720px;
+      margin: 0.85rem auto 0;
+      color: var(--muted);
+    }
+
+    footer {
+      padding: 2rem 1rem 2.5rem;
+      color: rgba(255, 255, 255, 0.68);
+      text-align: center;
+    }
+
+    @media (max-width: 820px) {
+      header {
+        align-items: flex-start;
+      }
+
+      nav {
+        gap: 0.75rem;
+      }
+
+      .hero {
+        min-height: auto;
+        text-align: left;
+        justify-items: start;
+      }
+
+      .hero-actions,
+      .actions {
+        justify-content: flex-start;
+      }
+
+      .split {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    @media (max-width: 560px) {
+      header {
+        padding: 0.85rem 1rem;
+      }
+
+      header img {
+        height: 36px;
+      }
+
+      nav a {
+        font-size: 0.88rem;
+      }
+
+      .cta {
+        width: 100%;
+      }
+
+      .card .actions {
+        align-items: stretch;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      html {
+        scroll-behavior: auto;
+      }
+
+      *,
+      *::before,
+      *::after {
+        transition-duration: 0.001ms !important;
+        animation-duration: 0.001ms !important;
+        animation-iteration-count: 1 !important;
+      }
+    }
+  </style>
+
+  <script defer src="/_vercel/insights/script.js"></script>
+</head>
+<body>
+  <header>
+    <a href="../index.html" aria-label="3dvr.tech home"><img src="../3DVR.png" alt="3dvr.tech logo" /></a>
+    <nav aria-label="Page navigation">
+      <a href="#monthly">Monthly</a>
+      <a href="#projects">Projects</a>
+      <a href="#loop">Business loop</a>
+      <a data-portal-path="/" href="https://portal.3dvr.tech/" target="_blank" rel="noopener">Portal</a>
+    </nav>
+  </header>
+
+  <main>
+    <section class="hero">
+      <span class="eyebrow">Plans and project sprints</span>
+      <h1>Build the future with 3DVR.</h1>
+      <p>
+        Open-source computing, AI workflows, 3D web experiences, and practical tools for creators,
+        events, small businesses, and people trying to get an idea into the world.
+      </p>
+      <p>
+        Join monthly, support the mission, or hire 3DVR to build your next microsite,
+        prototype, creative tech system, or practical launch page.
+      </p>
+      <div class="hero-actions" aria-label="Primary actions">
+        <a class="cta primary" href="mailto:3dvr.tech@gmail.com?subject=Start%20a%20%24300%20Starter%20Microsite">Start with a $300 Microsite</a>
+        <a class="cta secondary" data-portal-path="/billing/?plan=starter" href="https://portal.3dvr.tech/billing/?plan=starter" target="_blank" rel="noopener">Join as a $5 Supporter</a>
+      </div>
+    </section>
+
+    <section class="section" id="monthly" aria-labelledby="monthly-title">
+      <div class="section-heading center">
+        <span class="eyebrow">Monthly</span>
+        <h2 id="monthly-title">Choose how you want to build with 3DVR.</h2>
+        <p>
+          Support the mission monthly, get help building your own project, or work with 3DVR as an
+          ongoing AI, web, automation, and 3D technology partner.
+        </p>
+      </div>
+
+      <div class="grid plan-grid">
+        <article class="card">
+          <span class="card-label">Free Explorer</span>
+          <h3>Follow the mission</h3>
+          <div class="price">$0 / month</div>
+          <p>For people who want updates, demos, public tutorials, and a simple way to enter the network.</p>
+          <ul>
+            <li>Public 3DVR updates</li>
+            <li>Free demos and experiments</li>
+            <li>Public tutorials and resources</li>
+            <li>Open-source drops and intake form</li>
+          </ul>
+          <div class="actions">
+            <a class="cta primary" data-portal-path="/free-trial.html" href="https://portal.3dvr.tech/free-trial.html" target="_blank" rel="noopener">Join the network</a>
+          </div>
+        </article>
+
+        <article class="card">
+          <span class="card-label">Supporter</span>
+          <h3>Help fund the mission</h3>
+          <div class="price">$5 / month</div>
+          <p>For people who believe in open-source computing, AI tools, and 3D web experiments.</p>
+          <ul>
+            <li>Everything in Free</li>
+            <li>Early looks at experiments</li>
+            <li>Behind-the-scenes posts</li>
+            <li>Optional supporter badge or listing</li>
+          </ul>
+          <div class="actions">
+            <a class="cta primary" data-portal-path="/billing/?plan=starter" href="https://portal.3dvr.tech/billing/?plan=starter" target="_blank" rel="noopener">Become a Supporter</a>
+          </div>
+        </article>
+
+        <article class="card">
+          <span class="card-label">Creator</span>
+          <h3>Creative tech assistant</h3>
+          <div class="price">$20 / month</div>
+          <p>For artists, freelancers, small brands, event people, and builders shaping an idea.</p>
+          <ul>
+            <li>Templates and starter kits</li>
+            <li>Monthly AI, web, or brand idea review</li>
+            <li>Prompt packs for events and microsites</li>
+            <li>Discount on one-time builds</li>
+          </ul>
+          <div class="actions">
+            <a class="cta primary" data-portal-path="/billing/?plan=pro" href="https://portal.3dvr.tech/billing/?plan=pro" target="_blank" rel="noopener">Join Creator</a>
+          </div>
+        </article>
+
+        <article class="card featured">
+          <span class="card-label">Builder</span>
+          <h3>Build with 3DVR at your side</h3>
+          <div class="price">$50 / month</div>
+          <p>This is the main lane for people actively building a brand, event, website, offer, or tech project.</p>
+          <ul>
+            <li>One monthly mini-consult or async review</li>
+            <li>Landing page, offer, or funnel feedback</li>
+            <li>Priority support and reusable components</li>
+            <li>Discounted microsite setup</li>
+          </ul>
+          <div class="actions">
+            <a class="cta primary" data-portal-path="/billing/?plan=builder" href="https://portal.3dvr.tech/billing/?plan=builder" target="_blank" rel="noopener">Choose Builder</a>
+          </div>
+          <p class="note">Best first recurring plan after a one-time microsite goes live.</p>
+        </article>
+
+        <article class="card">
+          <span class="card-label">Partner</span>
+          <h3>Fractional AI/web/3D tech partner</h3>
+          <div class="price">$200 / month</div>
+          <p>For serious clients, small businesses, event teams, and collaborators who need ongoing support.</p>
+          <ul>
+            <li>Monthly project sprint</li>
+            <li>Web, AI, automation, and microsite support</li>
+            <li>Priority turnaround</li>
+            <li>Strategic planning for your brand or project</li>
+          </ul>
+          <div class="actions">
+            <a class="cta primary" data-portal-path="/billing/?plan=embedded" href="https://portal.3dvr.tech/billing/?plan=embedded" target="_blank" rel="noopener">Choose Partner</a>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="section" id="projects" aria-labelledby="projects-title">
+      <div class="section-heading center">
+        <span class="eyebrow">One-time projects</span>
+        <h2 id="projects-title">Start with a concrete deliverable.</h2>
+        <p>
+          One-time services are the cash-flow boosters: fast reviews, concept direction, microsites,
+          event pages, and custom deposits for deeper work.
+        </p>
+      </div>
+
+      <div class="grid">
+        <article class="card">
+          <span class="card-label">Quick Review</span>
+          <h3>Website, idea, offer, or event page feedback</h3>
+          <div class="price">$50</div>
+          <p>A short written review with 3 to 5 concrete improvements and a suggested next step.</p>
+          <div class="actions">
+            <a class="cta secondary" href="mailto:3dvr.tech@gmail.com?subject=3DVR%20Quick%20Review">Request review</a>
+          </div>
+        </article>
+
+        <article class="card">
+          <span class="card-label">Direction Sprint</span>
+          <h3>AI brand or event direction</h3>
+          <div class="price">$100</div>
+          <p>Turn an idea into a concept summary, landing page outline, visual direction, CTA, and next steps.</p>
+          <div class="actions">
+            <a class="cta secondary" href="mailto:3dvr.tech@gmail.com?subject=3DVR%20Direction%20Sprint">Request direction</a>
+          </div>
+        </article>
+
+        <article class="card featured">
+          <span class="card-label">Recommended start</span>
+          <h3>Starter Microsite</h3>
+          <div class="price">$300</div>
+          <p>A simple one-page website with copy, basic visuals, CTA/contact path, live link, and one revision.</p>
+          <div class="actions">
+            <a class="cta primary" href="mailto:3dvr.tech@gmail.com?subject=Start%20a%20%24300%20Starter%20Microsite">Start a $300 Microsite</a>
+          </div>
+          <p class="note">After launch, stay on Builder for updates, support, and monthly improvements.</p>
+        </article>
+
+        <article class="card">
+          <span class="card-label">Microsite Sprint</span>
+          <h3>Event or brand microsite</h3>
+          <div class="price">$500</div>
+          <p>A stronger one-page microsite with better mobile polish, event or brand sections, lead capture, and revisions.</p>
+          <div class="actions">
+            <a class="cta secondary" href="mailto:3dvr.tech@gmail.com?subject=3DVR%20%24500%20Microsite%20Sprint">Request sprint</a>
+          </div>
+        </article>
+
+        <article class="card">
+          <span class="card-label">Custom Build</span>
+          <h3>Interactive 3D, automation, prototype, or sponsor page</h3>
+          <div class="price">$1,000+</div>
+          <p>Use a custom build deposit when the project needs deeper systems, custom dashboards, or a larger sprint.</p>
+          <div class="actions">
+            <a class="cta secondary" href="mailto:3dvr.tech@gmail.com?subject=3DVR%20Custom%20Build%20Deposit">Scope custom work</a>
+            <a class="cta secondary" data-portal-path="/billing/?plan=custom" href="https://portal.3dvr.tech/billing/?plan=custom" target="_blank" rel="noopener">Custom checkout</a>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="section" id="ladder" aria-labelledby="ladder-title">
+      <div class="split">
+        <article class="panel">
+          <span class="eyebrow">The ladder</span>
+          <h2 id="ladder-title">Monthly support and one-time delivery should feed each other.</h2>
+          <p>
+            The subscription plans are for ongoing access, support, community, and collaboration.
+            One-time payments are for concrete deliverables.
+          </p>
+          <ul>
+            <li>Free to Supporter to Creator to Builder to Partner.</li>
+            <li>One-time $300 microsite to $50/month Builder support.</li>
+            <li>Custom build deposit to Partner if ongoing technical help is needed.</li>
+          </ul>
+        </article>
+
+        <article class="panel">
+          <span class="eyebrow">First recommendation</span>
+          <h2>Start with a $300 Microsite.</h2>
+          <p>
+            A real page funds the machine faster than vague planning, and it gives future monthly
+            support something concrete to improve.
+          </p>
+          <div class="actions">
+            <a class="cta primary" href="mailto:3dvr.tech@gmail.com?subject=Start%20a%20%24300%20Starter%20Microsite">Start the microsite</a>
+            <a class="cta secondary" data-portal-path="/billing/?plan=starter" href="https://portal.3dvr.tech/billing/?plan=starter" target="_blank" rel="noopener">Support for $5/month</a>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="section" id="loop" aria-labelledby="loop-title">
+      <div class="section-heading center">
+        <span class="eyebrow">Business engine</span>
+        <h2 id="loop-title">The agent’s job is narrow enough to work.</h2>
+        <p>
+          Sell and deliver 3DVR plans and microsite services. Find leads, recommend the right offer,
+          draft the pitch, help deploy, follow up, and turn one-time work into recurring support.
+        </p>
+      </div>
+
+      <div class="flow" aria-label="3DVR agent operating checklist">
+        <div class="flow-step"><strong>1. Find leads.</strong><span>Look for creators, event teams, freelancers, small businesses, and people with an idea that needs a real web presence.</span></div>
+        <div class="flow-step"><strong>2. Recommend the right product.</strong><span>Supporter, Creator, Builder, Partner, Quick Review, Direction Sprint, Microsite, or Custom Build.</span></div>
+        <div class="flow-step"><strong>3. Write the pitch and project intake.</strong><span>Use their words, define the deliverable, and make the next step obvious.</span></div>
+        <div class="flow-step"><strong>4. Draft, deploy, and follow up.</strong><span>Ship the page, ask for feedback, get a testimonial, and suggest Builder when monthly support makes sense.</span></div>
+      </div>
+    </section>
+
+    <section class="footer-cta" aria-labelledby="final-title">
+      <h2 id="final-title">Join 3DVR monthly, or hire us for a one-time sprint.</h2>
+      <p>
+        Whether you are launching an event, building a brand, creating a web experience, or exploring
+        the future of open computing, 3DVR gives you a practical way to start.
+      </p>
+      <div class="hero-actions">
+        <a class="cta primary" href="mailto:3dvr.tech@gmail.com?subject=Start%20a%20%24300%20Starter%20Microsite">Start with a $300 Microsite</a>
+        <a class="cta secondary" data-preserve-portal-origin href="../subscribe/index.html">Compare portal plans</a>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    © 2026 3dvr.tech — Build the tools. Share the power. Ship the page.
+  </footer>
+  <script src="/pwa.js"></script>
+  <script src="../subscribe/portal-links.js"></script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -55,6 +55,12 @@
     <priority>0.6</priority>
   </url>
   <url>
+    <loc>https://3dvr.tech/plans/</loc>
+    <lastmod>2026-06-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://3dvr.tech/subscribe/free-plan.html</loc>
     <lastmod>2025-10-10</lastmod>
     <changefreq>monthly</changefreq>

--- a/tests/plans-ladder.test.js
+++ b/tests/plans-ladder.test.js
@@ -1,0 +1,64 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+describe('3DVR plans ladder page', () => {
+  it('ships a dedicated plans and project sprints route', async () => {
+    const html = await readFile(new URL('../plans/index.html', import.meta.url), 'utf8');
+
+    assert.match(html, /<link rel="canonical" href="https:\/\/3dvr\.tech\/plans\/" \/>/);
+    assert.match(html, /<title>3DVR Plans and Project Sprints \| 3dvr\.tech<\/title>/);
+    assert.match(html, /Build the future with 3DVR\./);
+    assert.match(html, /Join 3DVR monthly, or hire us for a one-time sprint\./);
+    assert.match(html, /Start with a \$300 Microsite/);
+    assert.match(html, /Join as a \$5 Supporter/);
+    assert.match(html, /Sell and deliver 3DVR plans and microsite services/);
+    assert.match(html, /Find leads/);
+    assert.match(html, /turn one-time work into recurring support/);
+    assert.match(html, /<script defer src="\/_vercel\/insights\/script\.js"><\/script>/);
+    assert.match(html, /src="\.\.\/subscribe\/portal-links\.js"/);
+    assert.doesNotMatch(html, /hello@3dvr\.tech/);
+  });
+
+  it('maps monthly plan cards to existing portal billing lanes', async () => {
+    const html = await readFile(new URL('../plans/index.html', import.meta.url), 'utf8');
+
+    assert.match(html, /Free Explorer/);
+    assert.match(html, /Supporter/);
+    assert.match(html, /Creator/);
+    assert.match(html, /Builder/);
+    assert.match(html, /Partner/);
+    assert.match(html, /data-portal-path="\/free-trial\.html"/);
+    assert.match(html, /data-portal-path="\/billing\/\?plan=starter"/);
+    assert.match(html, /data-portal-path="\/billing\/\?plan=pro"/);
+    assert.match(html, /data-portal-path="\/billing\/\?plan=builder"/);
+    assert.match(html, /data-portal-path="\/billing\/\?plan=embedded"/);
+  });
+
+  it('lists the one-time services and uses project-intake contact CTAs', async () => {
+    const html = await readFile(new URL('../plans/index.html', import.meta.url), 'utf8');
+
+    assert.match(html, /Quick Review/);
+    assert.match(html, /\$50/);
+    assert.match(html, /Direction Sprint/);
+    assert.match(html, /\$100/);
+    assert.match(html, /Starter Microsite/);
+    assert.match(html, /\$300/);
+    assert.match(html, /Microsite Sprint/);
+    assert.match(html, /\$500/);
+    assert.match(html, /Custom Build/);
+    assert.match(html, /\$1,000\+/);
+    assert.match(html, /mailto:3dvr\.tech@gmail\.com\?subject=Start%20a%20%24300%20Starter%20Microsite/);
+    assert.match(html, /data-portal-path="\/billing\/\?plan=custom"/);
+  });
+
+  it('links the new route from the homepage and sitemap', async () => {
+    const homeHtml = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+    const sitemap = await readFile(new URL('../sitemap.xml', import.meta.url), 'utf8');
+
+    assert.match(homeHtml, /href="plans\/">Plans<\/a>/);
+    assert.match(homeHtml, /href="plans\/">\s*See plans\s*<\/a>/);
+    assert.match(homeHtml, /Open plans and project sprints/);
+    assert.match(sitemap, /<loc>https:\/\/3dvr\.tech\/plans\/<\/loc>/);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a new `/plans/` public offer page for the 3DVR monthly ladder and one-time project services.
- Link the new route from the homepage hero/nav and the existing plans section.
- Add `/plans/` to the sitemap.
- Add unit coverage for the route, billing handoff links, project-intake CTAs, homepage link, and sitemap entry.

## Offer framing
- Primary CTA: `Start with a $300 Microsite` via `3dvr.tech@gmail.com` project intake.
- Secondary CTA: `Join as a $5 Supporter` through portal billing.
- Monthly portal lanes reuse existing billing paths: free trial, starter, pro, builder, and embedded.
- One-time services use contact/intake CTAs until dedicated one-time Stripe products are wired.

## Validation
- `node --test tests/plans-ladder.test.js tests/customer-journey.test.js tests/vercel-insights-tag.test.js`
- `npm run test:unit`
- `git diff --check`
- Local browser check at `http://127.0.0.1:8091/plans/` verified desktop/mobile layout, no horizontal overflow, no missing page assets, homepage link wiring, and expected portal/mailto CTAs.

## Notes
- No portal, Stripe, backend, or API changes in this PR.
- This is a static subdirectory route, not a DNS/subdomain change.
