### PR TITLE
Make plans ladder an internal auto-business doc

### DIFF
--- a/auto-business/index.html
+++ b/auto-business/index.html
@@ -8,36 +8,36 @@
   <meta name="color-scheme" content="dark light" />
   <meta
     name="description"
-    content="Join 3DVR monthly or hire 3DVR for one-time website, AI workflow, microsite, and creative technology sprints."
+    content="Internal 3DVR auto-business design notes for the monthly offer ladder, one-time services, and agent sales loop."
   />
-  <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://3dvr.tech/plans/" />
-  <title>3DVR Plans and Project Sprints | 3dvr.tech</title>
+  <meta name="robots" content="noindex, nofollow" />
+  <link rel="canonical" href="https://3dvr.tech/auto-business/" />
+  <title>3DVR Auto-Business Design Notes | 3dvr.tech</title>
   <link rel="icon" href="../3DVRfavicon.png" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&family=Poppins:wght@600;700;800&display=swap" rel="stylesheet" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="3dvr.tech" />
-  <meta property="og:title" content="3DVR Plans and Project Sprints" />
+  <meta property="og:title" content="3DVR Auto-Business Design Notes" />
   <meta
     property="og:description"
-    content="Support the 3DVR mission monthly, get help building your project, or start with a focused microsite sprint."
+    content="A working internal design document for the 3DVR offer ladder, microsite services, and agent sales loop."
   />
-  <meta property="og:url" content="https://3dvr.tech/plans/" />
+  <meta property="og:url" content="https://3dvr.tech/auto-business/" />
   <meta property="og:image" content="https://3dvr.tech/3DVR.png" />
   <meta property="og:image:alt" content="3dvr.tech logomark" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="3DVR Plans and Project Sprints" />
+  <meta name="twitter:title" content="3DVR Auto-Business Design Notes" />
   <meta
     name="twitter:description"
-    content="Join monthly, support the mission, or hire 3DVR for a one-time website, microsite, or creative tech sprint."
+    content="Internal design notes for the 3DVR plans, project sprints, and self-funding agent business loop."
   />
   <meta name="twitter:image" content="https://3dvr.tech/3DVR.png" />
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Service",
-      "@id": "https://3dvr.tech/plans/#service",
-      "name": "3DVR plans and microsite services",
+      "@id": "https://3dvr.tech/auto-business/#service",
+      "name": "3DVR auto-business design notes",
       "provider": {
         "@type": "Organization",
         "@id": "https://3dvr.tech/#organization",
@@ -46,7 +46,7 @@
       },
       "serviceType": "Web design, AI workflow, creative technology, and microsite services",
       "areaServed": "US",
-      "url": "https://3dvr.tech/plans/"
+      "url": "https://3dvr.tech/auto-business/"
     }
   </script>
   <style>
@@ -479,38 +479,38 @@
   <header>
     <a href="../index.html" aria-label="3dvr.tech home"><img src="../3DVR.png" alt="3dvr.tech logo" /></a>
     <nav aria-label="Page navigation">
-      <a href="#monthly">Monthly</a>
-      <a href="#projects">Projects</a>
-      <a href="#loop">Business loop</a>
+      <a href="#monthly">Monthly ladder</a>
+      <a href="#projects">Project menu</a>
+      <a href="#loop">Agent loop</a>
       <a data-portal-path="/" href="https://portal.3dvr.tech/" target="_blank" rel="noopener">Portal</a>
     </nav>
   </header>
 
   <main>
     <section class="hero">
-      <span class="eyebrow">Plans and project sprints</span>
-      <h1>Build the future with 3DVR.</h1>
+      <span class="eyebrow">Internal design notes</span>
+      <h1>3DVR auto-business.</h1>
       <p>
-        Open-source computing, AI workflows, 3D web experiences, and practical tools for creators,
-        events, small businesses, and people trying to get an idea into the world.
+        A working design document for turning the existing 3DVR plans into a clearer business engine:
+        monthly support, one-time microsite services, and a narrow agent loop that sells and delivers the work.
       </p>
       <p>
-        Join monthly, support the mission, or hire 3DVR to build your next microsite,
-        prototype, creative tech system, or practical launch page.
+        This is not the primary public pricing page. Use it to keep the offer ladder, fulfillment logic,
+        and self-funding loop visible while the public site stays simpler.
       </p>
       <div class="hero-actions" aria-label="Primary actions">
-        <a class="cta primary" href="mailto:3dvr.tech@gmail.com?subject=Start%20a%20%24300%20Starter%20Microsite">Start with a $300 Microsite</a>
-        <a class="cta secondary" data-portal-path="/billing/?plan=starter" href="https://portal.3dvr.tech/billing/?plan=starter" target="_blank" rel="noopener">Join as a $5 Supporter</a>
+        <a class="cta primary" href="#projects">Review the project menu</a>
+        <a class="cta secondary" href="../subscribe/index.html">Open public plans</a>
       </div>
     </section>
 
     <section class="section" id="monthly" aria-labelledby="monthly-title">
       <div class="section-heading center">
-        <span class="eyebrow">Monthly</span>
-        <h2 id="monthly-title">Choose how you want to build with 3DVR.</h2>
+        <span class="eyebrow">Monthly ladder</span>
+        <h2 id="monthly-title">The recurring plan ladder.</h2>
         <p>
-          Support the mission monthly, get help building your own project, or work with 3DVR as an
-          ongoing AI, web, automation, and 3D technology partner.
+          The public version can stay short. This internal view keeps the intent of each monthly lane clear:
+          audience, support, creator help, active builder support, and deeper partner work.
         </p>
       </div>
 
@@ -601,10 +601,10 @@
     <section class="section" id="projects" aria-labelledby="projects-title">
       <div class="section-heading center">
         <span class="eyebrow">One-time projects</span>
-        <h2 id="projects-title">Start with a concrete deliverable.</h2>
+        <h2 id="projects-title">The concrete service menu.</h2>
         <p>
-          One-time services are the cash-flow boosters: fast reviews, concept direction, microsites,
-          event pages, and custom deposits for deeper work.
+          One-time services are the cash-flow boosters. The public recommendation can be a $300 microsite,
+          while this page remembers the full menu and upsell path.
         </p>
       </div>
 
@@ -713,20 +713,20 @@
     </section>
 
     <section class="footer-cta" aria-labelledby="final-title">
-      <h2 id="final-title">Join 3DVR monthly, or hire us for a one-time sprint.</h2>
+      <h2 id="final-title">Keep the public page simple. Keep the operating model here.</h2>
       <p>
-        Whether you are launching an event, building a brand, creating a web experience, or exploring
-        the future of open computing, 3DVR gives you a practical way to start.
+        The public site can point people to a simple plan or microsite offer. This internal route keeps
+        the broader auto-business loop available for sales, delivery, follow-up, and agent work.
       </p>
       <div class="hero-actions">
-        <a class="cta primary" href="mailto:3dvr.tech@gmail.com?subject=Start%20a%20%24300%20Starter%20Microsite">Start with a $300 Microsite</a>
-        <a class="cta secondary" data-preserve-portal-origin href="../subscribe/index.html">Compare portal plans</a>
+        <a class="cta primary" data-preserve-portal-origin href="../subscribe/index.html">Open public plans</a>
+        <a class="cta secondary" href="mailto:3dvr.tech@gmail.com?subject=3DVR%20Auto-Business%20Notes">Send a note</a>
       </div>
     </section>
   </main>
 
   <footer>
-    © 2026 3dvr.tech — Build the tools. Share the power. Ship the page.
+    © 2026 3dvr.tech — Internal offer design notes.
   </footer>
   <script src="/pwa.js"></script>
   <script src="../subscribe/portal-links.js"></script>

--- a/index.html
+++ b/index.html
@@ -1615,7 +1615,7 @@
       <a href="subscribe/index.html">Start Free</a>
       <a href="#vision">What We Do</a>
       <a href="#system">System</a>
-      <a href="plans/">Plans</a>
+      <a href="#subscribe">Plans</a>
       <a href="#testimonials">Trust</a>
       <a href="https://portal.3dvr.tech">Portal</a>
     </nav>
@@ -1671,7 +1671,7 @@
           >
             Start a project
           </a>
-          <a class="hero-button hero-button--ghost" data-growth-cta="see-plans" href="plans/">
+          <a class="hero-button hero-button--ghost" data-growth-cta="see-plans" href="#subscribe">
             See plans
           </a>
         </div>
@@ -1838,7 +1838,7 @@
   <section id="subscribe" style="background: var(--bg-subscribe);">
     <h2>Simple ways to work together</h2>
     <p class="section-lede">
-      Need the full ladder with one-time services? <a href="plans/">Open plans and project sprints</a>.
+      Internal offer notes: <a href="auto-business/">auto-business design document</a>.
     </p>
     <div class="card-grid">
       <a

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -55,12 +55,6 @@
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://3dvr.tech/plans/</loc>
-    <lastmod>2026-06-10</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
     <loc>https://3dvr.tech/subscribe/free-plan.html</loc>
     <lastmod>2025-10-10</lastmod>
     <changefreq>monthly</changefreq>

--- a/tests/auto-business.test.js
+++ b/tests/auto-business.test.js
@@ -2,16 +2,17 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
-describe('3DVR plans ladder page', () => {
-  it('ships a dedicated plans and project sprints route', async () => {
-    const html = await readFile(new URL('../plans/index.html', import.meta.url), 'utf8');
+describe('3DVR auto-business design document', () => {
+  it('ships a quieter internal design document route', async () => {
+    const html = await readFile(new URL('../auto-business/index.html', import.meta.url), 'utf8');
 
-    assert.match(html, /<link rel="canonical" href="https:\/\/3dvr\.tech\/plans\/" \/>/);
-    assert.match(html, /<title>3DVR Plans and Project Sprints \| 3dvr\.tech<\/title>/);
-    assert.match(html, /Build the future with 3DVR\./);
-    assert.match(html, /Join 3DVR monthly, or hire us for a one-time sprint\./);
+    assert.match(html, /<link rel="canonical" href="https:\/\/3dvr\.tech\/auto-business\/" \/>/);
+    assert.match(html, /<meta name="robots" content="noindex, nofollow" \/>/);
+    assert.match(html, /<title>3DVR Auto-Business Design Notes \| 3dvr\.tech<\/title>/);
+    assert.match(html, /3DVR auto-business\./);
+    assert.match(html, /This is not the primary public pricing page\./);
+    assert.match(html, /Internal offer design notes\./);
     assert.match(html, /Start with a \$300 Microsite/);
-    assert.match(html, /Join as a \$5 Supporter/);
     assert.match(html, /Sell and deliver 3DVR plans and microsite services/);
     assert.match(html, /Find leads/);
     assert.match(html, /turn one-time work into recurring support/);
@@ -21,7 +22,7 @@ describe('3DVR plans ladder page', () => {
   });
 
   it('maps monthly plan cards to existing portal billing lanes', async () => {
-    const html = await readFile(new URL('../plans/index.html', import.meta.url), 'utf8');
+    const html = await readFile(new URL('../auto-business/index.html', import.meta.url), 'utf8');
 
     assert.match(html, /Free Explorer/);
     assert.match(html, /Supporter/);
@@ -36,7 +37,7 @@ describe('3DVR plans ladder page', () => {
   });
 
   it('lists the one-time services and uses project-intake contact CTAs', async () => {
-    const html = await readFile(new URL('../plans/index.html', import.meta.url), 'utf8');
+    const html = await readFile(new URL('../auto-business/index.html', import.meta.url), 'utf8');
 
     assert.match(html, /Quick Review/);
     assert.match(html, /\$50/);
@@ -52,13 +53,17 @@ describe('3DVR plans ladder page', () => {
     assert.match(html, /data-portal-path="\/billing\/\?plan=custom"/);
   });
 
-  it('links the new route from the homepage and sitemap', async () => {
+  it('keeps the homepage link low-key and removes the route from the sitemap', async () => {
     const homeHtml = await readFile(new URL('../index.html', import.meta.url), 'utf8');
     const sitemap = await readFile(new URL('../sitemap.xml', import.meta.url), 'utf8');
 
-    assert.match(homeHtml, /href="plans\/">Plans<\/a>/);
-    assert.match(homeHtml, /href="plans\/">\s*See plans\s*<\/a>/);
-    assert.match(homeHtml, /Open plans and project sprints/);
-    assert.match(sitemap, /<loc>https:\/\/3dvr\.tech\/plans\/<\/loc>/);
+    assert.match(homeHtml, /href="#subscribe">Plans<\/a>/);
+    assert.match(homeHtml, /href="#subscribe">\s*See plans\s*<\/a>/);
+    assert.match(homeHtml, /Internal offer notes: <a href="auto-business\/">auto-business design document<\/a>/);
+    assert.doesNotMatch(homeHtml, /href="auto-business\/">Plans<\/a>/);
+    assert.doesNotMatch(homeHtml, /href="auto-business\/">\s*See plans\s*<\/a>/);
+    assert.doesNotMatch(homeHtml, /Open plans and project sprints/);
+    assert.doesNotMatch(sitemap, /<loc>https:\/\/3dvr\.tech\/plans\/<\/loc>/);
+    assert.doesNotMatch(sitemap, /<loc>https:\/\/3dvr\.tech\/auto-business\/<\/loc>/);
   });
 });


### PR DESCRIPTION
## Summary
- Rename the public `/plans/` ladder page to `/auto-business/` and reframe it as an internal design document.
- Add `noindex, nofollow` metadata and remove the route from `sitemap.xml`.
- Restore the homepage nav and hero `See plans` button to the normal on-page plans section.
- Keep only a quieter lower-page homepage link labeled as internal offer notes.
- Update tests to enforce the demoted/internal behavior.

## Validation
- `node --test tests/auto-business.test.js tests/customer-journey.test.js tests/vercel-insights-tag.test.js`
- `npm run test:unit`
- `git diff --check`
- Local browser check at `http://127.0.0.1:8092/auto-business/` verified `noindex`, no mobile overflow, no missing route assets, homepage nav/hero plan links point to `#subscribe`, and the auto-business link is not in the main nav.

## Notes
- No portal, Stripe, backend, or API changes.
- This intentionally keeps the auto-business plan available as a static internal-ish document without making it a primary public sales route.
