### PR TITLE
[codex] Remove homepage token hover zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -708,6 +708,10 @@
       background: transparent;
       border-color: transparent;
       box-shadow: none;
+      transform:
+        translate3d(0, 0, 0)
+        rotateX(calc(var(--hero-tilt-y, 0) * -1deg))
+        rotateY(calc(var(--hero-tilt-x, 0) * 1deg));
     }
 
     .hero-logo-card > img {

--- a/tests/logo-branding.test.js
+++ b/tests/logo-branding.test.js
@@ -23,6 +23,11 @@ describe('3dvr-web logo branding', () => {
     assert.match(html, /Interactive 3dvr\.tech 3D token/);
     assert.match(html, /\.hero-logo-card > img/);
     assert.match(html, /\.hero-token\[data-token-ready="true"\] \.hero-token__fallback/);
+    const tokenHoverRule = html.match(
+      /\.hero-logo-card--token:hover,\s+\.hero-logo-card--token:focus-visible\s+\{(?<body>[\s\S]*?)\n\s+\}/
+    )?.groups?.body ?? '';
+    assert.match(tokenHoverRule, /translate3d\(0, 0, 0\)/);
+    assert.doesNotMatch(tokenHoverRule, /scale\(/);
     assert.match(html, /homepage-logo-token\.js/);
     assert.match(html, /app-boot-enabled/);
     assert.match(html, /display-mode: standalone/);


### PR DESCRIPTION
## Summary

Removes the homepage 3D token container's inherited hover zoom so the coin keeps spinning without enlarging under the cursor.

## Impact

The main 3dvr.tech homepage keeps the interactive 3D logo behavior, but the hover state no longer feels jumpy on desktop/laptop.

## Validation

- `node --test tests/logo-branding.test.js`
- Browser check on desktop and mobile confirmed the WebGL token renders, idle spin advances, and hover does not change the token card dimensions.