### PR TITLE
[codex] Open mail links in new tabs

### DIFF
--- a/auto-business/index.html
+++ b/auto-business/index.html
@@ -615,7 +615,7 @@
           <div class="price">$50</div>
           <p>A short written review with 3 to 5 concrete improvements and a suggested next step.</p>
           <div class="actions">
-            <a class="cta secondary" href="mailto:3dvr.tech@gmail.com?subject=3DVR%20Quick%20Review">Request review</a>
+            <a class="cta secondary" href="mailto:3dvr.tech@gmail.com?subject=3DVR%20Quick%20Review" target="_blank" rel="noopener noreferrer">Request review</a>
           </div>
         </article>
 
@@ -625,7 +625,7 @@
           <div class="price">$100</div>
           <p>Turn an idea into a concept summary, landing page outline, visual direction, CTA, and next steps.</p>
           <div class="actions">
-            <a class="cta secondary" href="mailto:3dvr.tech@gmail.com?subject=3DVR%20Direction%20Sprint">Request direction</a>
+            <a class="cta secondary" href="mailto:3dvr.tech@gmail.com?subject=3DVR%20Direction%20Sprint" target="_blank" rel="noopener noreferrer">Request direction</a>
           </div>
         </article>
 
@@ -635,7 +635,7 @@
           <div class="price">$300</div>
           <p>A simple one-page website with copy, basic visuals, CTA/contact path, live link, and one revision.</p>
           <div class="actions">
-            <a class="cta primary" href="mailto:3dvr.tech@gmail.com?subject=Start%20a%20%24300%20Starter%20Microsite">Start a $300 Microsite</a>
+            <a class="cta primary" href="mailto:3dvr.tech@gmail.com?subject=Start%20a%20%24300%20Starter%20Microsite" target="_blank" rel="noopener noreferrer">Start a $300 Microsite</a>
           </div>
           <p class="note">After launch, stay on Builder for updates, support, and monthly improvements.</p>
         </article>
@@ -646,7 +646,7 @@
           <div class="price">$500</div>
           <p>A stronger one-page microsite with better mobile polish, event or brand sections, lead capture, and revisions.</p>
           <div class="actions">
-            <a class="cta secondary" href="mailto:3dvr.tech@gmail.com?subject=3DVR%20%24500%20Microsite%20Sprint">Request sprint</a>
+            <a class="cta secondary" href="mailto:3dvr.tech@gmail.com?subject=3DVR%20%24500%20Microsite%20Sprint" target="_blank" rel="noopener noreferrer">Request sprint</a>
           </div>
         </article>
 
@@ -656,7 +656,7 @@
           <div class="price">$1,000+</div>
           <p>Use a custom build deposit when the project needs deeper systems, custom dashboards, or a larger sprint.</p>
           <div class="actions">
-            <a class="cta secondary" href="mailto:3dvr.tech@gmail.com?subject=3DVR%20Custom%20Build%20Deposit">Scope custom work</a>
+            <a class="cta secondary" href="mailto:3dvr.tech@gmail.com?subject=3DVR%20Custom%20Build%20Deposit" target="_blank" rel="noopener noreferrer">Scope custom work</a>
             <a class="cta secondary" data-portal-path="/billing/?plan=custom" href="https://portal.3dvr.tech/billing/?plan=custom" target="_blank" rel="noopener">Custom checkout</a>
           </div>
         </article>
@@ -687,7 +687,7 @@
             support something concrete to improve.
           </p>
           <div class="actions">
-            <a class="cta primary" href="mailto:3dvr.tech@gmail.com?subject=Start%20a%20%24300%20Starter%20Microsite">Start the microsite</a>
+            <a class="cta primary" href="mailto:3dvr.tech@gmail.com?subject=Start%20a%20%24300%20Starter%20Microsite" target="_blank" rel="noopener noreferrer">Start the microsite</a>
             <a class="cta secondary" data-portal-path="/billing/?plan=starter" href="https://portal.3dvr.tech/billing/?plan=starter" target="_blank" rel="noopener">Support for $5/month</a>
           </div>
         </article>
@@ -720,7 +720,7 @@
       </p>
       <div class="hero-actions">
         <a class="cta primary" data-preserve-portal-origin href="../subscribe/index.html">Open public plans</a>
-        <a class="cta secondary" href="mailto:3dvr.tech@gmail.com?subject=3DVR%20Auto-Business%20Notes">Send a note</a>
+        <a class="cta secondary" href="mailto:3dvr.tech@gmail.com?subject=3DVR%20Auto-Business%20Notes" target="_blank" rel="noopener noreferrer">Send a note</a>
       </div>
     </section>
   </main>

--- a/dave/index.html
+++ b/dave/index.html
@@ -110,7 +110,7 @@
             For now, the page is structured so a real playlist can drop in
             without redesigning the section.
           </p>
-          <a class="button button-primary" href="mailto:3dvr.tech@gmail.com?subject=Dave%20audio%20reel%20request">Request the reel</a>
+          <a class="button button-primary" href="mailto:3dvr.tech@gmail.com?subject=Dave%20audio%20reel%20request" target="_blank" rel="noopener noreferrer">Request the reel</a>
         </div>
         <div class="reel-panel" aria-label="Audio reel placeholder">
           <div class="waveform" aria-hidden="true">
@@ -173,6 +173,8 @@
         <a
           class="button button-primary"
           href="mailto:3dvr.tech@gmail.com?subject=Dave%20audio%20production%20inquiry&amp;body=Hi%20Dave%2C%0A%0AI%27d%20like%20to%20talk%20about%20an%20audio%20project.%0A%0AProject%20type%3A%0ATimeline%3A%0AWhat%20I%20need%20help%20with%3A%0AReference%20links%3A%0A"
+          target="_blank"
+          rel="noopener noreferrer"
         >Book a session</a>
       </section>
     </main>

--- a/dist/about.html
+++ b/dist/about.html
@@ -77,7 +77,7 @@
             We move fast without rushing. We keep your voice intact. And we make sure every feature is
             tied to a real outcome: more clarity, more trust, and more conversions.
           </p>
-          <a class="button secondary" href="mailto:3dvr.tech@gmail.com">Contact the team</a>
+          <a class="button secondary" href="mailto:3dvr.tech@gmail.com" target="_blank" rel="noopener noreferrer">Contact the team</a>
         </div>
       </div>
     </section>
@@ -126,7 +126,7 @@
       <p>Reach us via the portal or email, and we’ll respond within a day.</p>
       <div class="hero-cta">
         <a class="button primary" href="https://portal.3dvr.tech">Open Portal</a>
-        <a class="button secondary" href="mailto:3dvr.tech@gmail.com">Email us</a>
+        <a class="button secondary" href="mailto:3dvr.tech@gmail.com" target="_blank" rel="noopener noreferrer">Email us</a>
       </div>
       <button class="button secondary" type="button" data-help-close style="margin-top: 16px;">Close</button>
     </div>

--- a/dist/index.html
+++ b/dist/index.html
@@ -281,7 +281,7 @@
           <p class="lead">Start free, then choose the plan that matches your momentum.</p>
           <div class="hero-cta">
             <a class="button primary" href="start.html">Get Started Free</a>
-            <a class="button secondary" href="mailto:3dvr.tech@gmail.com">Contact us</a>
+            <a class="button secondary" href="mailto:3dvr.tech@gmail.com" target="_blank" rel="noopener noreferrer">Contact us</a>
           </div>
         </div>
       </div>
@@ -331,7 +331,7 @@
       <p>Reach us via the portal or email, and we’ll respond within a day.</p>
       <div class="hero-cta">
         <a class="button primary" href="https://portal.3dvr.tech">Open Portal</a>
-        <a class="button secondary" href="mailto:3dvr.tech@gmail.com">Email us</a>
+        <a class="button secondary" href="mailto:3dvr.tech@gmail.com" target="_blank" rel="noopener noreferrer">Email us</a>
       </div>
       <button class="button secondary" type="button" data-help-close style="margin-top: 16px;">Close</button>
     </div>

--- a/dist/pricing.html
+++ b/dist/pricing.html
@@ -91,7 +91,7 @@
         <div class="card">
           <h2>Enterprise / Custom</h2>
           <p class="lead">Need dedicated support, complex automations, or white-label work? We’ll scope a custom plan.</p>
-          <a class="button primary" href="mailto:3dvr.tech@gmail.com">Contact for custom</a>
+          <a class="button primary" href="mailto:3dvr.tech@gmail.com" target="_blank" rel="noopener noreferrer">Contact for custom</a>
         </div>
       </div>
     </section>
@@ -164,7 +164,7 @@
       <p>Reach us via the portal or email, and we’ll respond within a day.</p>
       <div class="hero-cta">
         <a class="button primary" href="https://portal.3dvr.tech">Open Portal</a>
-        <a class="button secondary" href="mailto:3dvr.tech@gmail.com">Email us</a>
+        <a class="button secondary" href="mailto:3dvr.tech@gmail.com" target="_blank" rel="noopener noreferrer">Email us</a>
       </div>
       <button class="button secondary" type="button" data-help-close style="margin-top: 16px;">Close</button>
     </div>

--- a/dist/start.html
+++ b/dist/start.html
@@ -151,7 +151,7 @@
       <p>Reach us via the portal or email, and we’ll respond within a day.</p>
       <div class="hero-cta">
         <a class="button primary" href="https://portal.3dvr.tech">Open Portal</a>
-        <a class="button secondary" href="mailto:3dvr.tech@gmail.com">Email us</a>
+        <a class="button secondary" href="mailto:3dvr.tech@gmail.com" target="_blank" rel="noopener noreferrer">Email us</a>
       </div>
       <button class="button secondary" type="button" data-help-close style="margin-top: 16px;">Close</button>
     </div>

--- a/launch-in-3-days.html
+++ b/launch-in-3-days.html
@@ -815,7 +815,7 @@
         <div class="panel">
           <h3>If you need to talk first</h3>
           <p>
-            Email <a href="mailto:3dvr.tech@gmail.com?subject=Launch%20in%203%20Days">3dvr.tech@gmail.com</a> with what you are trying to build and what is blocking it.
+            Email <a href="mailto:3dvr.tech@gmail.com?subject=Launch%20in%203%20Days" target="_blank" rel="noopener noreferrer">3dvr.tech@gmail.com</a> with what you are trying to build and what is blocking it.
           </p>
           <p>
             Keep it short. The fastest way to move is to describe the build, the blockage, and what a win would look like.

--- a/launch-your-site.html
+++ b/launch-your-site.html
@@ -587,7 +587,7 @@
 
       <div class="header-actions">
         <a class="mini-link" href="subscribe/index.html">See plans</a>
-        <a class="header-cta" href="mailto:3dvr.tech@gmail.com?subject=3DVR%20Project%20Inquiry">Message me</a>
+        <a class="header-cta" href="mailto:3dvr.tech@gmail.com?subject=3DVR%20Project%20Inquiry" target="_blank" rel="noopener noreferrer">Message me</a>
       </div>
     </div>
   </header>
@@ -605,6 +605,8 @@
           <a
             class="button"
             href="mailto:3dvr.tech@gmail.com?subject=3DVR%20Project%20Inquiry&body=Hi%20Thomas%2C%0A%0AI%27m%20trying%20to%20launch%20a%20website%2C%20offer%2C%20or%20project.%20Here%27s%20what%20I%20need%3A%0A"
+            target="_blank"
+            rel="noopener noreferrer"
           >
             Message me
             <i class="fa-solid fa-arrow-right" aria-hidden="true"></i>
@@ -814,7 +816,7 @@
       </div>
 
       <div class="cta-actions">
-        <a class="button" href="mailto:3dvr.tech@gmail.com?subject=3DVR%20Project%20Inquiry">Message me</a>
+        <a class="button" href="mailto:3dvr.tech@gmail.com?subject=3DVR%20Project%20Inquiry" target="_blank" rel="noopener noreferrer">Message me</a>
         <a class="button-secondary" href="subscribe/index.html">See plans</a>
       </div>
     </section>

--- a/nomad-system.html
+++ b/nomad-system.html
@@ -639,7 +639,7 @@
             builder list and be part of the early movement.
           </p>
           <div class="hero-actions" style="justify-content: center;">
-            <a class="btn btn-primary" href="mailto:3dvr.tech@gmail.com?subject=3dvr%20Nomad%20System">
+            <a class="btn btn-primary" href="mailto:3dvr.tech@gmail.com?subject=3dvr%20Nomad%20System" target="_blank" rel="noopener noreferrer">
               Email 3dvr.tech
             </a>
             <a class="btn btn-secondary" href="index.html">

--- a/repair/index.html
+++ b/repair/index.html
@@ -457,7 +457,7 @@
         <a href="#story">The Story</a>
         <a href="#break">The Break</a>
         <a href="#join">Join 3DVR</a>
-        <a class="btn primary" href="mailto:3dvr.tech@gmail.com?subject=I%20want%20to%20join%203DVR">Start Building</a>
+        <a class="btn primary" href="mailto:3dvr.tech@gmail.com?subject=I%20want%20to%20join%203DVR" target="_blank" rel="noopener noreferrer">Start Building</a>
       </div>
     </div>
   </nav>
@@ -642,7 +642,7 @@
           We can build local tools, open tools, humane tools, beautiful tools, and business systems that help real people create value again. That is the 3DVR invitation.
         </p>
         <div class="hero-actions" style="justify-content: center;">
-          <a class="btn primary" href="mailto:3dvr.tech@gmail.com?subject=I%20want%20to%20join%203DVR&amp;body=Hi%203DVR%2C%0A%0AI%20want%20to%20join%20or%20support%20the%20mission.%20Here%27s%20what%20I%27m%20building%20or%20what%20I%20need%20help%20with%3A%0A">Join the mission</a>
+          <a class="btn primary" href="mailto:3dvr.tech@gmail.com?subject=I%20want%20to%20join%203DVR&amp;body=Hi%203DVR%2C%0A%0AI%20want%20to%20join%20or%20support%20the%20mission.%20Here%27s%20what%20I%27m%20building%20or%20what%20I%20need%20help%20with%3A%0A" target="_blank" rel="noopener noreferrer">Join the mission</a>
           <a class="btn" href="https://3dvr.tech">Visit 3dvr.tech</a>
         </div>
       </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -290,7 +290,7 @@
         </p>
         <div class="cta-buttons">
           <a class="btn" href="../index.html#subscribe">View membership plans</a>
-          <a class="btn" href="mailto:3dvr.tech@gmail.com">Request a custom build</a>
+          <a class="btn" href="mailto:3dvr.tech@gmail.com" target="_blank" rel="noopener noreferrer">Request a custom build</a>
         </div>
       </div>
     </section>

--- a/tests/mailto-links.test.js
+++ b/tests/mailto-links.test.js
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(testDir, '..');
+
+function listTrackedHtmlFiles() {
+  const stdout = execFileSync('git', ['-C', repoRoot, 'ls-files', '*.html'], { encoding: 'utf8' }).trim();
+  return stdout ? stdout.split('\n') : [];
+}
+
+test('tracked mailto links open in a new tab without taking over the site', () => {
+  const failures = [];
+  const mailtoLinkPattern = /<a\b(?=[^>]*\bhref=(['"])mailto:)[^>]*>/gis;
+
+  for (const relativePath of listTrackedHtmlFiles()) {
+    const absolutePath = path.join(repoRoot, relativePath);
+    const source = readFileSync(absolutePath, 'utf8');
+    const links = source.match(mailtoLinkPattern) || [];
+
+    for (const link of links) {
+      if (!/\btarget=(['"])_blank\1/i.test(link)) {
+        failures.push(`${relativePath}: mailto link is missing target="_blank"`);
+      }
+
+      const relMatch = /\brel=(['"])(.*?)\1/i.exec(link);
+      const relValues = relMatch?.[2].toLowerCase().split(/\s+/) || [];
+      if (!relValues.includes('noopener')) {
+        failures.push(`${relativePath}: mailto link is missing rel="noopener"`);
+      }
+    }
+  }
+
+  assert.deepEqual(failures, []);
+});

--- a/truth/index.html
+++ b/truth/index.html
@@ -224,7 +224,7 @@
         <a href="#pillars" class="text-gold/90 hover:text-aurum">Vision</a>
       </nav>
       <div class="flex justify-start md:justify-end">
-        <a href="mailto:3dvr.tech@gmail.com" class="text-white/70 hover:text-aurum">3dvr.tech@gmail.com</a>
+        <a href="mailto:3dvr.tech@gmail.com" class="text-white/70 hover:text-aurum" target="_blank" rel="noopener noreferrer">3dvr.tech@gmail.com</a>
       </div>
     </div>
   </footer>  <script>


### PR DESCRIPTION
## What changed

- Added `target="_blank"` and `rel="noopener noreferrer"` to tracked static HTML `mailto:` links so clicking email CTAs does not navigate away from the current site tab.
- Updated Dave's mail links specifically, including the reel request and booking CTA.
- Added a unit test that scans tracked HTML files and fails if a `mailto:` link lacks `target="_blank"` or `rel="noopener"`.

## Impact

Desktop users can click mail CTAs without losing the current website tab. The canonical 3DVR email remains `3dvr.tech@gmail.com`.

## Validation

- `npm run test:unit`
- `git diff --check`
- Mechanical scan of tracked HTML mailto links confirmed all include `_blank` and `noopener`.