### PR TITLE
[codex] Link repair page to subscriptions

### DIFF
--- a/repair/index.html
+++ b/repair/index.html
@@ -457,7 +457,7 @@
         <a href="#story">The Story</a>
         <a href="#break">The Break</a>
         <a href="#join">Join 3DVR</a>
-        <a class="btn primary" href="mailto:3dvr.tech@gmail.com?subject=I%20want%20to%20join%203DVR" target="_blank" rel="noopener noreferrer">Start Building</a>
+        <a class="btn primary" href="/subscribe/">View plans</a>
       </div>
     </div>
   </nav>
@@ -642,7 +642,7 @@
           We can build local tools, open tools, humane tools, beautiful tools, and business systems that help real people create value again. That is the 3DVR invitation.
         </p>
         <div class="hero-actions" style="justify-content: center;">
-          <a class="btn primary" href="mailto:3dvr.tech@gmail.com?subject=I%20want%20to%20join%203DVR&amp;body=Hi%203DVR%2C%0A%0AI%20want%20to%20join%20or%20support%20the%20mission.%20Here%27s%20what%20I%27m%20building%20or%20what%20I%20need%20help%20with%3A%0A" target="_blank" rel="noopener noreferrer">Join the mission</a>
+          <a class="btn primary" href="/subscribe/">View subscriptions</a>
           <a class="btn" href="https://3dvr.tech">Visit 3dvr.tech</a>
         </div>
       </div>

--- a/tests/repair-page.test.js
+++ b/tests/repair-page.test.js
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('repair page routes primary calls to subscriptions instead of email', async () => {
+  const html = await readFile(new URL('../repair/index.html', import.meta.url), 'utf8');
+
+  assert.match(html, /<link rel="canonical" href="https:\/\/3dvr\.tech\/repair\/" \/>/);
+  assert.match(html, /<a class="btn primary" href="\/subscribe\/">View plans<\/a>/);
+  assert.match(html, /<a class="btn primary" href="\/subscribe\/">View subscriptions<\/a>/);
+  assert.doesNotMatch(html, /mailto:/);
+});


### PR DESCRIPTION
## What changed

- Changed the repair page header CTA from an email link to `/subscribe/` with the label `View plans`.
- Changed the final repair page CTA from an email link to `/subscribe/` with the label `View subscriptions`.
- Added a repair-page unit test to keep the primary CTAs routed to subscriptions and ensure the repair page does not reintroduce `mailto:` links.

## Impact

`https://3dvr.tech/repair/` now sends visitors to the subscriptions page for conversion instead of opening email for the primary actions.

## Validation

- `npm run test:unit`
- `git diff --check`
- Local Playwright smoke checks at laptop and mobile widths: no horizontal overflow, no repair mail links, both subscription CTAs present, canonical URL intact.