### PR TITLE
[codex] Add site backlinks

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -573,6 +573,11 @@
       flex-wrap: wrap;
     }
 
+    .footer-row a {
+      color: var(--text);
+      font-weight: 800;
+    }
+
     @media (max-width: 980px) {
       h1 {
         font-size: 4.8rem;
@@ -689,11 +694,12 @@
 <body>
   <header>
     <nav class="wrap">
-      <a class="brand" href="#top" aria-label="3DVR home">
+      <a class="brand" href="/" aria-label="3DVR home">
         <span class="mark">3D</span>
         <span>3DVR</span>
       </a>
       <div class="nav-links">
+        <a href="/">Home</a>
         <a href="#systems">Services</a>
         <a href="#manifesto">Approach</a>
         <a href="#plans">Plans</a>
@@ -899,7 +905,7 @@
   <footer>
     <div class="wrap footer-row">
       <span>© <span id="year"></span> 3DVR Productions</span>
-      <span>Build The Future · Creating Universal Experiences</span>
+      <span><a href="/">3dvr.tech home</a> · Build The Future · Creating Universal Experiences</span>
     </div>
   </footer>
 

--- a/dave/index.html
+++ b/dave/index.html
@@ -181,7 +181,10 @@
 
     <footer class="site-footer">
       <p>Dave · Independent audio producer</p>
-      <a href="#top">Back to top</a>
+      <div class="footer-links">
+        <a href="#top">Back to top</a>
+        <a href="https://3dvr.tech/">made by 3dvr.tech</a>
+      </div>
     </footer>
   </body>
 </html>

--- a/dave/styles.css
+++ b/dave/styles.css
@@ -394,6 +394,13 @@ h3 {
   color: var(--muted);
 }
 
+.footer-links {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
 @media (max-width: 980px) {
   .intro-section,
   .reel-section,
@@ -465,6 +472,10 @@ h3 {
 
   .site-footer {
     display: grid;
+  }
+
+  .footer-links {
+    justify-content: flex-start;
   }
 }
 

--- a/repair/index.html
+++ b/repair/index.html
@@ -436,6 +436,16 @@
       flex-wrap: wrap;
     }
 
+    .footer-inner a {
+      color: var(--text);
+      font-weight: 800;
+      text-decoration: none;
+    }
+
+    .footer-inner a:hover {
+      color: var(--accent);
+    }
+
     @media (max-width: 900px) {
       .hero-grid, .split { grid-template-columns: 1fr; }
       .orb-card { min-height: 420px; }
@@ -449,11 +459,12 @@
 <body>
   <nav class="nav">
     <div class="wrap nav-inner">
-      <a class="brand" href="#top" aria-label="3DVR home">
+      <a class="brand" href="/" aria-label="3DVR home">
         <span class="mark">3D</span>
         <span>3DVR</span>
       </a>
       <div class="nav-links">
+        <a href="/">Home</a>
         <a href="#story">The Story</a>
         <a href="#break">The Break</a>
         <a href="#join">Join 3DVR</a>
@@ -652,7 +663,7 @@
   <footer>
     <div class="wrap footer-inner">
       <div>© <span id="year"></span> 3DVR · Creating Universal Experiences</div>
-      <div>Open tools · Human agency · Practical consciousness</div>
+      <div><a href="/">3dvr.tech home</a> · Open tools · Human agency · Practical consciousness</div>
     </div>
   </footer>
 

--- a/tests/build-page.test.js
+++ b/tests/build-page.test.js
@@ -6,6 +6,9 @@ test('build page presents the public offer and routes calls to subscriptions', a
   const html = await readFile(new URL('../build/index.html', import.meta.url), 'utf8');
 
   assert.match(html, /<link rel="canonical" href="https:\/\/3dvr\.tech\/build\/" \/>/);
+  assert.match(html, /<a class="brand" href="\/" aria-label="3DVR home">/);
+  assert.match(html, /<a href="\/">Home<\/a>/);
+  assert.match(html, /<a href="\/">3dvr\.tech home<\/a>/);
   assert.match(html, /Compare subscriptions/);
   assert.match(html, /View all subscriptions/);
   assert.match(html, /href="\/subscribe\/"/);

--- a/tests/dave-page.test.js
+++ b/tests/dave-page.test.js
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('Dave page links attribution back to 3dvr.tech', async () => {
+  const html = await readFile(new URL('../dave/index.html', import.meta.url), 'utf8');
+
+  assert.match(html, /<link rel="canonical" href="https:\/\/dave\.3dvr\.tech\/" \/>/);
+  assert.match(html, /<a href="https:\/\/3dvr\.tech\/">made by 3dvr\.tech<\/a>/);
+});

--- a/tests/repair-page.test.js
+++ b/tests/repair-page.test.js
@@ -6,6 +6,9 @@ test('repair page routes primary calls to subscriptions instead of email', async
   const html = await readFile(new URL('../repair/index.html', import.meta.url), 'utf8');
 
   assert.match(html, /<link rel="canonical" href="https:\/\/3dvr\.tech\/repair\/" \/>/);
+  assert.match(html, /<a class="brand" href="\/" aria-label="3DVR home">/);
+  assert.match(html, /<a href="\/">Home<\/a>/);
+  assert.match(html, /<a href="\/">3dvr\.tech home<\/a>/);
   assert.match(html, /<a class="btn primary" href="\/subscribe\/">View plans<\/a>/);
   assert.match(html, /<a class="btn primary" href="\/subscribe\/">View subscriptions<\/a>/);
   assert.doesNotMatch(html, /mailto:/);


### PR DESCRIPTION
## Summary
- Added explicit home backlinks to `/repair/` and `/build/` via the brand/nav and footer
- Added a `made by 3dvr.tech` footer attribution link on Dave's page
- Added tests covering the new backlink requirements

## Verification
- `npm run test:unit`
- `git diff --check`
- Local Playwright smoke check for `/repair/`, `/build/`, and `/dave/` at 1366x768 and 390x844 with zero horizontal overflow