### PR TITLE
[codex] Remove unnecessary plan lane label

### DIFF
--- a/index.html
+++ b/index.html
@@ -1685,7 +1685,6 @@
 
   <section class="plan-lane-section" aria-labelledby="planLaneTitle">
     <div class="plan-lane-dock" aria-label="Quick plan links">
-      <span class="plan-lane-dock__label">Plans after the offer is clear</span>
       <h2 id="planLaneTitle" class="plan-lane-title">Pick the lane that fits.</h2>
       <p class="plan-lane-dock__intro">
         Start free if you are still organizing, or choose the lane that matches the support you need.

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -23,7 +23,7 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /data-portal-path="\/billing\/\?plan=pro"/);
     assert.match(html, /data-portal-path="\/billing\/\?plan=builder"/);
     assert.match(html, /data-portal-path="\/billing\/\?plan=embedded"/);
-    assert.match(html, /Plans after the offer is clear/);
+    assert.doesNotMatch(html, /Plans after the offer is clear/);
     assert.match(html, /Pick the lane that fits\./);
     assert.match(html, /Get organized first/);
     assert.match(html, /Light monthly support/);


### PR DESCRIPTION
## What changed

- Removed the homepage plan-lane label: `Plans after the offer is clear`.
- Updated the customer journey copy test to assert that phrase stays removed.

## Why

That line was unnecessary on the public 3dvr.tech homepage.

## Validation

- Ran `git diff --check`.
- Ran `node --test tests/customer-journey.test.js`.
