### PR TITLE
[codex] Add reclaim agency positioning docs

### DIFF
--- a/docs/reclaim-agency/README.md
+++ b/docs/reclaim-agency/README.md
@@ -1,0 +1,554 @@
+# Reclaim Agency
+
+## Working Positioning Documentation
+
+**Status:** Draft / living thesis  
+**Owner:** 3DVR / tmsteph  
+**Core idea:** People are not only upset about wealth inequality. They are upset because wealth concentration has become power concentration. Too much of life has been captured, and people need practical ways to reclaim agency.
+
+3DVR can become a studio for reclaiming agency: digital and physical infrastructure for people building useful alternatives at human scale.
+
+The simple version:
+
+> We help small projects become real.
+
+The deeper version:
+
+> Build useful systems that return agency to people and communities.
+
+---
+
+## 1. Core Thesis
+
+Wealth concentration has become power concentration.
+
+Power over:
+
+- Housing
+- Land
+- Food
+- Software
+- Media
+- Health
+- Education
+- Work
+- Attention
+- Culture
+- Spirituality
+- Imagination
+
+The message is not only:
+
+```txt
+The rich have too much money.
+```
+
+It is closer to:
+
+```txt
+Too much of life has been captured. We need to build ways for people to reclaim agency.
+```
+
+Agency is the key word. People want to feel like they can do something again.
+
+---
+
+## 2. Possible Thesis Line
+
+```txt
+The old dream was individual success.
+The new dream is collective agency.
+```
+
+This fits 3DVR and tmsteph because the goal is not to become another billionaire startup. The goal is to build tools, spaces, and networks that let regular people, families, artists, healers, builders, small businesses, and communities function outside total dependence on giant platforms.
+
+---
+
+## 3. Emotional Truth
+
+When people talk about concentration of wealth and power, they may be saying:
+
+```txt
+I feel trapped.
+```
+
+```txt
+I feel like no matter how hard I work, the game is already owned.
+```
+
+```txt
+I do not want my child growing up in a world where everything is rented, tracked, subscribed to, and optimized against them.
+```
+
+```txt
+I want to build something real, but I do not know where to start.
+```
+
+```txt
+I want community, land, tools, purpose, and freedom.
+```
+
+That is the opening for 3DVR.
+
+---
+
+## 4. Response: Reconstruction
+
+The response should not be revolution as destruction.
+
+It should be revolution as reconstruction.
+
+Not:
+
+```txt
+Burn it all down.
+```
+
+More like:
+
+```txt
+Build parallel systems that make the old ones less necessary.
+```
+
+Parallel systems can include:
+
+- Regenerative farms
+- Community retreats
+- Open-source software
+- Local business tools
+- Project websites
+- Creator networks
+- Ethical AI agents
+- Cooperative infrastructure
+- Land-based healing spaces
+- Music, therapy, and nature
+- Education for practical independence
+- Human-scale technology
+
+The useful distinction:
+
+```txt
+Yes, we see the problem. Now let's build.
+```
+
+---
+
+## 5. 3DVR Positioning
+
+Possible frames:
+
+```txt
+A studio for reclaiming agency.
+```
+
+```txt
+Digital and physical infrastructure for a freer world.
+```
+
+```txt
+Tools for people building the next society.
+```
+
+```txt
+We help small projects become real.
+```
+
+The last line is the simplest and strongest for customers. Most people do not need a manifesto first. They need help turning a feeling into a project.
+
+---
+
+## 6. Liberation Layers
+
+3DVR can organize its work around several agency layers.
+
+### 6.1 Digital Agency
+
+Websites, domains, email, booking, payment links, dashboards, and AI-assisted communication.
+
+Message:
+
+```txt
+You should not need a giant platform to exist online.
+```
+
+Related product:
+
+- 3DVR Project Desk
+- Repair/build pages
+- Small project microsites
+- Email and booking infrastructure
+
+### 6.2 Economic Agency
+
+Small businesses, side projects, cooperative services, local marketplaces, and creator tools.
+
+Message:
+
+```txt
+People need ways to earn without being swallowed by platforms.
+```
+
+Related product:
+
+- Subscription plans
+- Local services
+- Professional services
+- Builder support
+- Project launch kits
+
+### 6.3 Land and Food Agency
+
+Regenerative farming, retreats, seed-saving, farm stays, community gardens, and local food systems.
+
+Message:
+
+```txt
+Food and land should reconnect people to life, not just markets.
+```
+
+Related project:
+
+- Regenerative Farm
+- Button Willow / land search
+- Retreat and workshop infrastructure
+- Local food and land-access documentation
+
+### 6.4 Cultural Agency
+
+Music, events, media, storytelling, education, and spiritual gatherings.
+
+Message:
+
+```txt
+Culture should be made by communities, not extracted by algorithms.
+```
+
+Related project:
+
+- Dave audio producer page
+- Events and community pages
+- Music-led nature circles
+- Local creator network ideas
+
+### 6.5 Computing Agency
+
+Open source, local-first tools, personal servers, alternative OS ideas, RISC-V, and human-centered interfaces.
+
+Message:
+
+```txt
+The computer should belong to the person using it.
+```
+
+Related project:
+
+- 3DVR Portal
+- Open Tools Lab
+- Local-first experiments
+- Personal OS and computing sovereignty notes
+
+---
+
+## 7. Reclaim the Stack
+
+This framework connects the tech mission with the farm, regenerative, spiritual, and small-business mission.
+
+The stack of modern life has been captured:
+
+- Attention stack: social media
+- Commerce stack: Amazon, Stripe, platform marketplaces
+- Communication stack: Google, Meta, Apple
+- Computing stack: proprietary operating systems and clouds
+- Food stack: industrial agriculture
+- Land stack: real estate speculation
+- Culture stack: algorithms
+- Health stack: insurance and pharma
+- Education stack: debt credentials
+
+3DVR's mission:
+
+```txt
+Help people reclaim the stack, one layer at a time.
+```
+
+This is strong because it turns a broad political feeling into practical build work.
+
+---
+
+## 8. Slogans and Lines
+
+### Plain and Direct
+
+- Build useful systems. Return power to people.
+- Tools for a freer world.
+- Helping people reclaim agency.
+- Small projects. Real infrastructure. Human future.
+- Build the future outside the machine.
+
+### Spiritual
+
+- Raise consciousness. Build systems. Free the people.
+- The future is local, open, and alive.
+- Technology in service of life.
+- Reconnect the digital, the physical, and the spiritual.
+
+### Startup / Business
+
+- Infrastructure for independent projects.
+- The operating system for human-scale businesses.
+- Launch your project without selling your soul to platforms.
+- Websites, tools, and automation for people building something real.
+
+### More Radical
+
+- Power has centralized. We are decentralizing capability.
+- The future should not be owned by five companies.
+- We do not need permission to build better systems.
+- Exit extraction. Build regeneration.
+
+---
+
+## 9. Manifesto Seeds
+
+### Version A
+
+```txt
+Everywhere I go, I hear the same thing. People know something is wrong. Wealth, land, software, media, food, housing, and culture have been concentrated into too few hands. Most people do not want to just complain about it. They want to do something.
+
+3DVR exists to help people turn that feeling into useful systems: websites, tools, farms, events, retreats, small businesses, open-source projects, and community infrastructure.
+
+We are not waiting for permission. We are building the future at human scale.
+```
+
+### Version B
+
+```txt
+The problem is not only that some people have too much money.
+The problem is that too many people have lost access to the tools of life.
+
+We need access to land. Food. Housing. Software. Education. Health. Culture. Work. Community. Meaning.
+
+3DVR is about building practical systems that return agency to people and communities.
+```
+
+### Distilled Version
+
+```txt
+People everywhere can feel it: too much wealth, power, land, software, media, and culture has been concentrated into too few hands.
+
+3DVR is our response: build useful systems that return agency to people and communities.
+
+Websites. Tools. Farms. Retreats. Education. Open-source computing. Human-scale business. Regenerative culture.
+
+Not just resistance. Reconstruction.
+```
+
+---
+
+## 10. Join Angle
+
+People are tired of being told to:
+
+- Vote harder
+- Work harder
+- Post harder
+- Buy better products
+- Wait for billionaires to save us
+
+Better invitation:
+
+```txt
+Start where you are. Build one useful thing. Connect it to other useful things.
+```
+
+This can become a 3DVR principle.
+
+You do not need to solve capitalism in one move. Build:
+
+- One website
+- One garden
+- One workshop
+- One retreat
+- One open-source tool
+- One local business
+- One community event
+- One alternative workflow
+- One small income stream
+- One mutual support network
+
+Then connect them.
+
+---
+
+## 11. Regenerative Farm Connection
+
+The farm project can become the physical anchor of this worldview.
+
+Not just:
+
+```txt
+We want a farm.
+```
+
+More like:
+
+```txt
+A living prototype for regenerative life.
+```
+
+The farm can combine:
+
+- Food
+- Land restoration
+- Family life
+- Music
+- Group healing
+- Nature-based retreats
+- Open-source tools
+- Small business incubation
+- Community events
+- Low-cost living experiments
+- Digital infrastructure
+- Education
+
+The farm demonstrates the bigger idea:
+
+```txt
+What if technology, land, healing, and small business all worked together for human freedom?
+```
+
+---
+
+## 12. Practical Offers
+
+### 12.1 Project Desk
+
+For people with an idea but no infrastructure.
+
+Includes:
+
+- Domain or subdomain
+- Simple website
+- Contact form
+- Booking request
+- Payment link
+- Email forwarding
+- Dashboard
+- AI-drafted replies
+
+Message:
+
+```txt
+Get your project out of your head and into the world.
+```
+
+### 12.2 Regenerative Project Kit
+
+For farms, retreats, healers, artists, and local organizers.
+
+Includes:
+
+- Landing page
+- Event calendar
+- Donation or payment links
+- Volunteer intake
+- Retreat booking form
+- Newsletter
+- Community updates
+
+Message:
+
+```txt
+Infrastructure for people healing the world.
+```
+
+### 12.3 Local Freedom Network
+
+A directory of aligned projects.
+
+Includes:
+
+- Regenerative farms
+- Local makers
+- Musicians
+- Therapists and coaches
+- Open-source builders
+- Educators
+- Small businesses
+- Intentional communities
+
+Message:
+
+```txt
+Find people building outside the extraction economy.
+```
+
+### 12.4 Open Tools Lab
+
+For the computing and open-source side of 3DVR.
+
+Includes:
+
+- Experiments
+- Prototypes
+- Personal OS work
+- Local-first tools
+- AI agents
+- RISC-V and open hardware notes
+- Digital sovereignty guides
+
+Message:
+
+```txt
+Computing should serve consciousness, not capture it.
+```
+
+---
+
+## 13. Core Principles
+
+1. Help before hype.
+2. Tools over ideology.
+3. Community over extraction.
+4. Open systems over locked platforms.
+5. Regeneration over endless growth.
+6. Human agency over automation for its own sake.
+7. Local roots, global network.
+8. Technology in service of life.
+
+---
+
+## 14. Important Tone Rule
+
+This should not sound like another political rant page.
+
+The magic is:
+
+```txt
+Yes, we see the problem. Now let's build.
+```
+
+This gives people somewhere to put their frustration.
+
+Possible line:
+
+```txt
+We are not here to doomscroll the collapse. We are here to build the alternatives.
+```
+
+---
+
+## 15. Next Uses
+
+This document can feed:
+
+- 3dvr.tech homepage messaging
+- `/build` marketing copy
+- `/repair` manifesto copy
+- 3DVR Project Desk positioning
+- Regenerative Farm page framing
+- Portal app categories
+- Local Freedom Network planning
+- Subscription tier descriptions
+- Outreach emails and sales language
+


### PR DESCRIPTION
## Summary
- Adds `docs/reclaim-agency/README.md` as a new 3DVR positioning documentation directory.
- Organizes the agency thesis, Reclaim the Stack framework, liberation layers, slogans, manifesto seeds, farm connection, practical offers, and principles.
- Connects the material back to Project Desk, regenerative projects, local freedom networks, Open Tools Lab, `/build`, `/repair`, and 3DVR subscriptions/positioning work.

## Validation
- `npm run test:unit`
- `git diff --check`
