### PR TITLE
[codex] Move system overview to dedicated page

### DIFF
--- a/homepage-logo-token.js
+++ b/homepage-logo-token.js
@@ -4,6 +4,10 @@
   const IDLE_QUARTER_SPIN_SPEED = (Math.PI * 2) / 18000;
   const IDLE_WOBBLE_X = 0.025;
   const IDLE_WOBBLE_Z = 0.012;
+  const DRAG_SPIN_FACTOR = 0.018;
+  const MAX_SPIN_MOMENTUM = 0.014;
+  const MIN_SPIN_MOMENTUM = 0.00008;
+  const SPIN_MOMENTUM_DECAY = 0.992;
   const root = document.querySelector('[data-3dvr-token]');
   const canvas = document.querySelector('[data-3dvr-token-canvas]');
 
@@ -23,16 +27,21 @@
     restY: 0,
     restZ: 0,
     idleSpin: 0,
+    spinVelocityY: 0,
     lastTimestamp: 0,
+    lastDragTimestamp: 0,
     renderer: null,
     fallbackContext: null,
     camera: null,
     scene: null,
     token: null,
     frame: 0,
-    interactionsReady: false,
-    dragIdleTimer: 0
+    interactionsReady: false
   };
+
+  function clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
+  }
 
   function loadThree() {
     if (window.THREE) return Promise.resolve(window.THREE);
@@ -178,8 +187,17 @@
     const elapsed = Math.min(timestamp - state.lastTimestamp, 64);
     state.lastTimestamp = timestamp;
 
-    if (!state.dragging) {
-      state.idleSpin += elapsed * IDLE_QUARTER_SPIN_SPEED;
+    if (state.dragging) {
+      return;
+    }
+
+    state.idleSpin += elapsed * (IDLE_QUARTER_SPIN_SPEED + state.spinVelocityY);
+
+    if (state.spinVelocityY !== 0) {
+      state.spinVelocityY *= Math.pow(SPIN_MOMENTUM_DECAY, elapsed / 16.67);
+      if (Math.abs(state.spinVelocityY) < MIN_SPIN_MOMENTUM) {
+        state.spinVelocityY = 0;
+      }
     }
   }
 
@@ -226,27 +244,34 @@
     state.dragging = true;
     state.lastX = event.clientX;
     state.lastY = event.clientY;
+    state.lastDragTimestamp = event.timeStamp || performance.now();
+    state.spinVelocityY = 0;
     root.setPointerCapture?.(event.pointerId);
   }
 
   function drag(event) {
     if (!state.dragging) return;
-    window.clearTimeout(state.dragIdleTimer);
     const dx = event.clientX - state.lastX;
     const dy = event.clientY - state.lastY;
+    const timestamp = event.timeStamp || performance.now();
+    const elapsed = Math.max(16, Math.min(timestamp - state.lastDragTimestamp, 80));
+    const spinDelta = dx * DRAG_SPIN_FACTOR;
     state.lastX = event.clientX;
     state.lastY = event.clientY;
-    state.targetY += dx * 0.014;
-    state.targetX += dy * 0.014;
-    state.targetZ += (dx - dy) * 0.002;
-    state.dragIdleTimer = window.setTimeout(() => {
-      state.dragging = false;
-    }, 140);
+    state.lastDragTimestamp = timestamp;
+    state.idleSpin += spinDelta;
+    state.spinVelocityY = clamp(
+      state.spinVelocityY * 0.35 + (spinDelta / elapsed) * 0.65,
+      -MAX_SPIN_MOMENTUM,
+      MAX_SPIN_MOMENTUM
+    );
+    state.targetY += spinDelta * 0.18;
+    state.targetX += dy * 0.012;
+    state.targetZ += (dx - dy) * 0.0015;
   }
 
   function endDrag(event) {
     state.dragging = false;
-    window.clearTimeout(state.dragIdleTimer);
     root.releasePointerCapture?.(event.pointerId);
   }
 
@@ -372,6 +397,7 @@
           manualY: state.currentY,
           manualZ: state.currentZ,
           idleSpin: state.idleSpin,
+          spinVelocityY: state.spinVelocityY,
           wobbleX: rotation.wobbleX,
           wobbleZ: rotation.wobbleZ,
           targetX: state.targetX,

--- a/index.html
+++ b/index.html
@@ -1184,92 +1184,6 @@
         radial-gradient(circle at top left, rgba(0, 255, 200, 0.16), transparent 34%),
         linear-gradient(135deg, #102033 0%, #173b51 55%, #2c4d5f 100%);
     }
-    .system-layers-section {
-      background:
-        radial-gradient(circle at top right, rgba(0, 255, 200, 0.16), transparent 34%),
-        linear-gradient(135deg, #081018 0%, #102236 52%, #173547 100%);
-    }
-    .system-shell {
-      width: min(1120px, calc(100% - 2rem));
-      margin: 0 auto;
-      display: grid;
-      gap: 1.5rem;
-    }
-    .system-heading {
-      max-width: 840px;
-      margin: 0 auto;
-      text-align: center;
-    }
-    .system-kicker {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      padding: 0.42rem 0.75rem;
-      border-radius: 999px;
-      background: rgba(255, 255, 255, 0.08);
-      color: #d8fff4;
-      font-size: 0.84rem;
-      font-weight: 600;
-      letter-spacing: 0.02em;
-      margin-bottom: 0.95rem;
-    }
-    .system-heading p {
-      max-width: 760px;
-      margin-left: auto;
-      margin-right: auto;
-    }
-    .system-grid {
-      display: grid;
-      grid-template-columns: repeat(3, minmax(0, 1fr));
-      gap: 1.25rem;
-    }
-    .system-card {
-      background: rgba(7, 18, 28, 0.54);
-      border: 1px solid rgba(255, 255, 255, 0.12);
-      border-radius: 24px;
-      padding: 1.45rem;
-      box-shadow: 0 18px 38px rgba(0, 0, 0, 0.24);
-      text-align: left;
-    }
-    .system-card__eyebrow {
-      display: inline-flex;
-      align-items: center;
-      margin-bottom: 0.8rem;
-      padding: 0.32rem 0.62rem;
-      border-radius: 999px;
-      background: rgba(255, 255, 255, 0.08);
-      color: #d8fff4;
-      font-size: 0.8rem;
-      font-weight: 700;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-    }
-    .system-card p {
-      color: rgba(255, 255, 255, 0.84);
-    }
-    .system-points {
-      list-style: none;
-      padding: 0;
-      margin: 1rem 0 0;
-      display: grid;
-      gap: 0.7rem;
-    }
-    .system-points li {
-      padding: 0.75rem 0.9rem;
-      border-radius: 16px;
-      background: rgba(255, 255, 255, 0.06);
-      border: 1px solid rgba(255, 255, 255, 0.08);
-      color: rgba(255, 255, 255, 0.88);
-    }
-    .system-points strong {
-      color: #d7fff2;
-    }
-    .system-actions {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.9rem;
-      justify-content: center;
-    }
     .nomad-shell {
       width: min(1120px, calc(100% - 2rem));
       margin: 0 auto;
@@ -1618,7 +1532,7 @@
     <nav id="mainNav">
       <a href="subscribe/index.html">Start Free</a>
       <a href="#vision">What We Do</a>
-      <a href="#system">System</a>
+      <a href="system.html">System</a>
       <a href="#subscribe">Plans</a>
       <a href="#testimonials">Trust</a>
       <a href="https://portal.3dvr.tech">Portal</a>
@@ -1782,62 +1696,6 @@
             <li>Practical systems for leads, content, and operations.</li>
           </ul>
         </article>
-      </div>
-    </div>
-  </section>
-
-  <section id="system" class="system-layers-section">
-    <div class="system-shell">
-      <div class="system-heading">
-        <span class="system-kicker">One system. Any device.</span>
-        <h2>Portal, Browser, OS</h2>
-        <p>
-          Start in your browser. Grow into your own operating system. The same 3dvr account,
-          apps, and support lane can move from cloud workspace to browser runtime to deeper
-          Linux-based control without starting over.
-        </p>
-      </div>
-      <div class="system-grid">
-        <article class="system-card">
-          <span class="system-card__eyebrow">Portal</span>
-          <h3>Cloud workspace and identity</h3>
-          <p>
-            Keep billing, CRM, notes, messaging, projects, and AI on one account instead of
-            scattering the work across disconnected tools.
-          </p>
-          <ul class="system-points">
-            <li><strong>Start here:</strong> subscriptions, contacts, notes, support, and daily operating lanes.</li>
-            <li><strong>Same account:</strong> one identity across planning, delivery, and collaboration.</li>
-          </ul>
-        </article>
-        <article class="system-card">
-          <span class="system-card__eyebrow">Browser</span>
-          <h3>Runtime, launcher, and media environment</h3>
-          <p>
-            The portal is also becoming a browser-shaped workspace: app launcher, multi-panel tools,
-            media experiments, AI workbench, and lighter desktop-like flows that run anywhere.
-          </p>
-          <ul class="system-points">
-            <li><strong>Run in tabs today:</strong> launcher, notes, CRM, media, and AI tools.</li>
-            <li><strong>Grow into a workspace:</strong> same apps, but with more context and control.</li>
-          </ul>
-        </article>
-        <article class="system-card">
-          <span class="system-card__eyebrow">OS</span>
-          <h3>TommyOS direction for deeper control</h3>
-          <p>
-            Long term, 3dvr is moving toward a Linux-based operating layer for devices, local servers,
-            hardware experiments, and a calmer builder environment that does not depend on closed platforms.
-          </p>
-          <ul class="system-points">
-            <li><strong>Start practical:</strong> Pocket Workstation, Debian experiments, and open workflows.</li>
-            <li><strong>Deeper later:</strong> same identity, same apps, deeper levels of control.</li>
-          </ul>
-        </article>
-      </div>
-      <div class="system-actions">
-        <a class="cta" href="https://portal.3dvr.tech" target="_blank" rel="noopener">Open the portal command center</a>
-        <a class="cta" href="pocket-workstation.html" data-growth-cta="system-pocket-workstation">See Pocket Workstation</a>
       </div>
     </div>
   </section>
@@ -2173,6 +2031,9 @@
     </div>
     <a class="cta" href="https://portal.3dvr.tech" target="_blank" rel="noopener" style="display: inline-flex; align-items: center; gap: 0.5rem;">
       Open portal.3dvr.tech <i class="fas fa-arrow-right" aria-hidden="true"></i>
+    </a>
+    <a class="cta" href="system.html" style="display: inline-flex; align-items: center; gap: 0.5rem; margin-left: 0.75rem;">
+      See full system map <i class="fas fa-layer-group" aria-hidden="true"></i>
     </a>
   </section>
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,8 @@
-const CACHE_NAME = '3dvr-cache-v4';
+const CACHE_NAME = '3dvr-cache-v5';
 const OFFLINE_ASSETS = [
   '/',
   '/index.html',
+  '/system.html',
   '/assets/logo-3dvr.svg',
   '/3DVR.png',
   '/3DVRfavicon.png'

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -37,6 +37,12 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://3dvr.tech/system.html</loc>
+    <lastmod>2026-06-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://3dvr.tech/pages/portfolio.html</loc>
     <lastmod>2025-10-10</lastmod>
     <changefreq>monthly</changefreq>

--- a/system.html
+++ b/system.html
@@ -1,0 +1,483 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta
+    name="description"
+    content="The 3dvr system map: one account across the portal, browser workspace, and longer-term Linux-based OS direction."
+  />
+  <meta name="robots" content="index, follow" />
+  <link rel="canonical" href="https://3dvr.tech/system.html" />
+  <title>3dvr.tech System Map</title>
+  <link rel="icon" type="image/svg+xml" href="/assets/logo-3dvr.svg" />
+  <link rel="alternate icon" href="3DVRfavicon.png" />
+  <script defer src="/_vercel/insights/script.js"></script>
+  <style>
+    :root {
+      --bg: #07111a;
+      --panel: rgba(255, 255, 255, 0.08);
+      --panel-strong: rgba(7, 18, 28, 0.72);
+      --line: rgba(255, 255, 255, 0.13);
+      --text: #f5fbff;
+      --muted: #bdd5df;
+      --accent: #00ffc8;
+      --warm: #ffbd73;
+      --max: 1120px;
+      --shadow: 0 22px 70px rgba(0, 0, 0, 0.32);
+    }
+
+    * { box-sizing: border-box; }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      margin: 0;
+      font-family: Inter, Arial, sans-serif;
+      color: var(--text);
+      background:
+        radial-gradient(circle at 18% 12%, rgba(0, 255, 200, 0.22), transparent 28rem),
+        radial-gradient(circle at 85% 8%, rgba(255, 189, 115, 0.18), transparent 24rem),
+        linear-gradient(180deg, #07111a 0%, #0c1c29 48%, #071018 100%);
+      line-height: 1.65;
+    }
+
+    a {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    .shell {
+      width: min(var(--max), calc(100% - 2rem));
+      margin: 0 auto;
+    }
+
+    .site-header {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      background: rgba(5, 13, 20, 0.78);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+      backdrop-filter: blur(14px);
+    }
+
+    .nav {
+      min-height: 72px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.7rem;
+      font-weight: 800;
+      letter-spacing: 0.01em;
+    }
+
+    .brand img {
+      width: 42px;
+      height: 42px;
+      border-radius: 12px;
+      box-shadow: var(--shadow);
+    }
+
+    .nav-links {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+      gap: 0.75rem;
+    }
+
+    .nav-links a {
+      color: var(--muted);
+      font-weight: 700;
+      font-size: 0.95rem;
+      padding: 0.45rem 0.65rem;
+      border-radius: 6px;
+    }
+
+    .nav-links a:hover {
+      color: var(--text);
+      background: rgba(255, 255, 255, 0.08);
+    }
+
+    .hero {
+      padding: clamp(4rem, 8vw, 7rem) 0 3.5rem;
+    }
+
+    .hero-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1.05fr) minmax(280px, 0.95fr);
+      gap: 1.5rem;
+      align-items: center;
+    }
+
+    .kicker,
+    .card-eyebrow {
+      display: inline-flex;
+      align-items: center;
+      width: fit-content;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.08);
+      color: #d8fff4;
+      font-weight: 800;
+    }
+
+    .kicker {
+      padding: 0.45rem 0.78rem;
+      margin-bottom: 1rem;
+      font-size: 0.86rem;
+    }
+
+    h1,
+    h2,
+    h3 {
+      margin-top: 0;
+      line-height: 1.05;
+    }
+
+    h1 {
+      max-width: 11ch;
+      margin-bottom: 1rem;
+      font-size: clamp(3rem, 8vw, 6.4rem);
+    }
+
+    h2 {
+      font-size: clamp(2rem, 4vw, 3.2rem);
+      margin-bottom: 0.85rem;
+    }
+
+    h3 {
+      font-size: clamp(1.2rem, 2vw, 1.55rem);
+      margin-bottom: 0.75rem;
+    }
+
+    p {
+      color: var(--muted);
+      margin-top: 0;
+    }
+
+    .hero-copy {
+      max-width: 62ch;
+      font-size: 1.1rem;
+    }
+
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.85rem;
+      margin-top: 1.4rem;
+    }
+
+    .button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 48px;
+      padding: 0.85rem 1.15rem;
+      border-radius: 8px;
+      font-weight: 800;
+    }
+
+    .button-primary {
+      background: var(--accent);
+      color: #03120f;
+    }
+
+    .button-secondary {
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid var(--line);
+    }
+
+    .system-panel {
+      position: relative;
+      display: grid;
+      gap: 0.85rem;
+      padding: 1.2rem;
+      background: var(--panel-strong);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }
+
+    .system-panel::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, rgba(0, 255, 200, 0.12), transparent 46%, rgba(255, 189, 115, 0.1));
+      pointer-events: none;
+    }
+
+    .system-panel > * {
+      position: relative;
+    }
+
+    .layer-row {
+      display: grid;
+      grid-template-columns: 86px 1fr;
+      gap: 0.9rem;
+      align-items: center;
+      padding: 0.9rem;
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 8px;
+    }
+
+    .layer-row strong {
+      color: #d8fff4;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 0.82rem;
+    }
+
+    .layer-row span {
+      color: var(--muted);
+    }
+
+    .section {
+      padding: 3.5rem 0;
+    }
+
+    .section-heading {
+      max-width: 780px;
+      margin-bottom: 1.4rem;
+    }
+
+    .system-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 1rem;
+    }
+
+    .system-card,
+    .note-card {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      box-shadow: var(--shadow);
+    }
+
+    .system-card {
+      padding: 1.3rem;
+    }
+
+    .card-eyebrow {
+      margin-bottom: 0.85rem;
+      padding: 0.34rem 0.62rem;
+      font-size: 0.78rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .points {
+      list-style: none;
+      padding: 0;
+      margin: 1rem 0 0;
+      display: grid;
+      gap: 0.7rem;
+    }
+
+    .points li {
+      padding: 0.75rem 0.85rem;
+      border-radius: 8px;
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      color: rgba(255, 255, 255, 0.88);
+    }
+
+    .points strong {
+      color: #d7fff2;
+    }
+
+    .notes-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 1rem;
+    }
+
+    .note-card {
+      padding: 1.25rem;
+    }
+
+    .note-card h3 {
+      color: var(--accent);
+    }
+
+    .footer {
+      padding: 2rem 0 2.5rem;
+      color: var(--muted);
+      text-align: center;
+    }
+
+    @media (max-width: 880px) {
+      .hero-grid,
+      .system-grid,
+      .notes-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .nav {
+        align-items: flex-start;
+        flex-direction: column;
+        padding: 1rem 0;
+      }
+
+      h1 {
+        max-width: 12ch;
+      }
+    }
+
+    @media (max-width: 520px) {
+      .layer-row {
+        grid-template-columns: 1fr;
+      }
+
+      .button {
+        width: 100%;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header class="site-header">
+    <div class="shell nav">
+      <a class="brand" href="index.html" aria-label="3dvr.tech home">
+        <img src="/assets/logo-3dvr.svg" alt="" />
+        <span>3dvr.tech</span>
+      </a>
+      <nav class="nav-links" aria-label="System page navigation">
+        <a href="index.html">Home</a>
+        <a href="#layers">Layers</a>
+        <a href="#direction">Direction</a>
+        <a href="https://portal.3dvr.tech">Portal</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <div class="shell hero-grid">
+        <div>
+          <span class="kicker">One system. Any device.</span>
+          <h1>Portal, Browser, OS</h1>
+          <p class="hero-copy">
+            Start in your browser. Grow into your own operating system. The same 3dvr account,
+            apps, and support lane can move from cloud workspace to browser runtime to deeper
+            Linux-based control without starting over.
+          </p>
+          <div class="actions">
+            <a class="button button-primary" href="https://portal.3dvr.tech" target="_blank" rel="noopener">Open the portal command center</a>
+            <a class="button button-secondary" href="pocket-workstation.html">See Pocket Workstation</a>
+          </div>
+        </div>
+
+        <aside class="system-panel" aria-label="3dvr system layers">
+          <div class="layer-row">
+            <strong>Portal</strong>
+            <span>Cloud workspace, identity, subscriptions, notes, CRM, messaging, support, and AI.</span>
+          </div>
+          <div class="layer-row">
+            <strong>Browser</strong>
+            <span>Launcher, multi-panel tools, media experiments, AI workbench, and workspace runtime.</span>
+          </div>
+          <div class="layer-row">
+            <strong>OS</strong>
+            <span>Linux-based control for devices, local servers, hardware experiments, and calmer building.</span>
+          </div>
+        </aside>
+      </div>
+    </section>
+
+    <section id="layers" class="section">
+      <div class="shell">
+        <div class="section-heading">
+          <h2>Three levels of the same account</h2>
+          <p>
+            The system starts practical and gets deeper only when the work calls for it.
+          </p>
+        </div>
+
+        <div class="system-grid">
+          <article class="system-card">
+            <span class="card-eyebrow">Portal</span>
+            <h3>Cloud workspace and identity</h3>
+            <p>
+              Keep billing, CRM, notes, messaging, projects, and AI on one account instead of
+              scattering the work across disconnected tools.
+            </p>
+            <ul class="points">
+              <li><strong>Start here:</strong> subscriptions, contacts, notes, support, and daily operating lanes.</li>
+              <li><strong>Same account:</strong> one identity across planning, delivery, and collaboration.</li>
+            </ul>
+          </article>
+
+          <article class="system-card">
+            <span class="card-eyebrow">Browser</span>
+            <h3>Runtime, launcher, and media environment</h3>
+            <p>
+              The portal is also becoming a browser-shaped workspace: app launcher, multi-panel tools,
+              media experiments, AI workbench, and lighter desktop-like flows that run anywhere.
+            </p>
+            <ul class="points">
+              <li><strong>Run in tabs today:</strong> launcher, notes, CRM, media, and AI tools.</li>
+              <li><strong>Grow into a workspace:</strong> same apps, but with more context and control.</li>
+            </ul>
+          </article>
+
+          <article class="system-card">
+            <span class="card-eyebrow">OS</span>
+            <h3>TommyOS direction for deeper control</h3>
+            <p>
+              Long term, 3dvr is moving toward a Linux-based operating layer for devices, local servers,
+              hardware experiments, and a calmer builder environment that does not depend on closed platforms.
+            </p>
+            <ul class="points">
+              <li><strong>Start practical:</strong> Pocket Workstation, Debian experiments, and open workflows.</li>
+              <li><strong>Deeper later:</strong> same identity, same apps, deeper levels of control.</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="direction" class="section">
+      <div class="shell">
+        <div class="section-heading">
+          <h2>What this changes</h2>
+          <p>
+            3dvr can stay simple for a new customer while still pointing toward a stronger builder environment.
+          </p>
+        </div>
+        <div class="notes-grid">
+          <article class="note-card">
+            <h3>Start with service</h3>
+            <p>
+              A customer can begin with a website, a support lane, or the portal dashboard without learning a new operating system first.
+            </p>
+          </article>
+          <article class="note-card">
+            <h3>Keep the path open</h3>
+            <p>
+              The same work can later expand into portable workstations, Debian browser experiments, local servers, and deeper Linux control.
+            </p>
+          </article>
+        </div>
+        <div class="actions">
+          <a class="button button-primary" href="https://portal.3dvr.tech" target="_blank" rel="noopener">Open portal.3dvr.tech</a>
+          <a class="button button-secondary" href="nomad-system.html">Explore the nomad system</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="shell">
+      <p>&copy; 2026 3dvr.tech. One account across portal, browser, and deeper open systems.</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -76,6 +76,21 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /Read the broader vision/);
     assert.match(html, /href="nomad-system\.html"/);
     assert.match(html, /What the stack includes/);
+    assert.match(html, /Portal command center/);
+    assert.match(html, /Start in the browser with one identity, one launcher, and one calmer operating lane\./);
+    assert.match(html, /Portal layer/);
+    assert.match(html, /OS direction/);
+    assert.match(html, /Open portal\.3dvr\.tech/);
+    assert.match(html, /href="system\.html"/);
+    assert.match(html, /See full system map/);
+    assert.doesNotMatch(html, /<section id="system"/);
+    assert.doesNotMatch(html, /Message me/i);
+    assert.doesNotMatch(html, /mailto:3dvr\.tech@gmail\.com\?subject=3DVR%20Project%20Inquiry/);
+    assert.doesNotMatch(html, /Plan your week\. Get support\. Launch work\./);
+  });
+
+  it('moves the full Portal Browser OS system map onto its own page', async () => {
+    const html = await readFile(new URL('../system.html', import.meta.url), 'utf8');
     assert.match(html, /One system\. Any device\./);
     assert.match(html, /Portal, Browser, OS/);
     assert.match(html, /Start in your browser\. Grow into your own operating system\./);
@@ -87,15 +102,8 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /Runtime, launcher, and media environment/);
     assert.match(html, /TommyOS direction for deeper control/);
     assert.match(html, /Open the portal command center/);
-    assert.match(html, /data-growth-cta="system-pocket-workstation"/);
-    assert.match(html, /Portal command center/);
-    assert.match(html, /Start in the browser with one identity, one launcher, and one calmer operating lane\./);
-    assert.match(html, /Portal layer/);
-    assert.match(html, /OS direction/);
-    assert.match(html, /Open portal\.3dvr\.tech/);
-    assert.doesNotMatch(html, /Message me/i);
-    assert.doesNotMatch(html, /mailto:3dvr\.tech@gmail\.com\?subject=3DVR%20Project%20Inquiry/);
-    assert.doesNotMatch(html, /Plan your week\. Get support\. Launch work\./);
+    assert.match(html, /href="pocket-workstation\.html"/);
+    assert.match(html, /href="nomad-system\.html"/);
   });
 
   it('keeps the portfolio projects room visually connected to the world', async () => {

--- a/tests/logo-branding.test.js
+++ b/tests/logo-branding.test.js
@@ -33,6 +33,9 @@ describe('3dvr-web logo branding', () => {
     assert.match(token, /IDLE_QUARTER_SPIN_SPEED = \(Math\.PI \* 2\) \/ 18000/);
     assert.match(token, /IDLE_WOBBLE_X = 0\.025/);
     assert.match(token, /IDLE_WOBBLE_Z = 0\.012/);
+    assert.match(token, /DRAG_SPIN_FACTOR = 0\.018/);
+    assert.match(token, /MAX_SPIN_MOMENTUM = 0\.014/);
+    assert.match(token, /SPIN_MOMENTUM_DECAY = 0\.992/);
     assert.match(token, /CylinderGeometry/);
     assert.match(token, /TorusGeometry/);
     assert.match(token, /CanvasTexture/);
@@ -40,7 +43,8 @@ describe('3dvr-web logo branding', () => {
     assert.match(token, /targetY: 0/);
     assert.match(token, /targetZ: 0/);
     assert.match(token, /idleSpin/);
-    assert.match(token, /state\.idleSpin \+= elapsed \* IDLE_QUARTER_SPIN_SPEED/);
+    assert.match(token, /spinVelocityY/);
+    assert.match(token, /state\.idleSpin \+= elapsed \* \(IDLE_QUARTER_SPIN_SPEED \+ state\.spinVelocityY\)/);
     assert.doesNotMatch(token, /idleSpin = .*% \(Math\.PI \* 2\)/);
     assert.match(token, /getRenderRotation/);
     assert.match(token, /pointerdown/);

--- a/tests/playwright/homepage-mobile.spec.js
+++ b/tests/playwright/homepage-mobile.spec.js
@@ -136,15 +136,21 @@ test.describe('homepage mobile sticky CTA', () => {
 
     await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
     await page.mouse.down();
-    await page.mouse.move(box.x + box.width / 2 + 95, box.y + box.height / 2 + 48, { steps: 6 });
+    await page.mouse.move(box.x + box.width / 2 + 140, box.y + box.height / 2 + 28, { steps: 2 });
     await page.mouse.up();
+    await page.waitForTimeout(180);
+
+    const boosted = await page.evaluate(() => window.__3dvrLogoToken.getRotation());
+    expect(boosted.spinVelocityY).toBeGreaterThan(0.002);
+
     await page.waitForTimeout(1800);
 
     const released = await page.evaluate(() => window.__3dvrLogoToken.getRotation());
     expect(Math.abs(released.manualX)).toBeLessThan(0.08);
     expect(Math.abs(released.manualY)).toBeLessThan(0.08);
     expect(Math.abs(released.manualZ)).toBeLessThan(0.08);
-    expect(released.idleSpin).toBeGreaterThan(spinning.idleSpin);
-    expect(released.y).toBeGreaterThan(spinning.y);
+    expect(released.spinVelocityY).toBeLessThan(boosted.spinVelocityY);
+    expect(released.idleSpin).toBeGreaterThan(boosted.idleSpin + 1.4);
+    expect(released.y).toBeGreaterThan(boosted.y + 1.4);
   });
 });


### PR DESCRIPTION
## What changed

- Moved the full "One system. Any device / Portal, Browser, OS" homepage section into a new `system.html` page.
- Updated the homepage nav and portal summary section to link to the new system map.
- Added `system.html` to the sitemap and service worker offline cache.
- Updated customer journey tests so the homepage checks the handoff link and `system.html` owns the full system-map copy.

## Why

The homepage was carrying a long strategic section that fits better as its own deeper page. The homepage now stays shorter while still preserving a clear path to the full Portal / Browser / OS explanation.

## Validation

- Passed: `node --test tests/customer-journey.test.js tests/service-worker.test.js`
- Passed local HTTP smoke checks for `/` and `/system.html`.
- Full `npm run test:unit` still has unrelated existing failures:
  - `tests/life-plan.test.js` expects old homepage copy: "Choose one of three lanes..."
  - `tests/vercel-insights-tag.test.js` reports `3dvr-world/prize.html` missing the Vercel Insights tag.