### PR TITLE
[codex] Move nomad overview off homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1174,83 +1174,6 @@
       grid-column: 1 / -1;
       justify-self: center;
     }
-    .nomad-system-section {
-      background:
-        radial-gradient(circle at top left, rgba(0, 255, 200, 0.16), transparent 34%),
-        linear-gradient(135deg, #102033 0%, #173b51 55%, #2c4d5f 100%);
-    }
-    .nomad-shell {
-      width: min(1120px, calc(100% - 2rem));
-      margin: 0 auto;
-    }
-    .nomad-grid {
-      display: grid;
-      grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
-      gap: 1.5rem;
-      align-items: stretch;
-    }
-    .nomad-card {
-      background: rgba(7, 18, 28, 0.48);
-      border: 1px solid rgba(255, 255, 255, 0.12);
-      border-radius: 24px;
-      padding: 1.5rem;
-      box-shadow: 0 18px 38px rgba(0, 0, 0, 0.24);
-    }
-    .nomad-kicker {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      padding: 0.42rem 0.75rem;
-      border-radius: 999px;
-      background: rgba(255, 255, 255, 0.08);
-      color: #d8fff4;
-      font-size: 0.84rem;
-      font-weight: 600;
-      letter-spacing: 0.02em;
-      margin-bottom: 0.95rem;
-    }
-    .nomad-card h2,
-    .nomad-card h3 {
-      margin-bottom: 0.8rem;
-    }
-    .nomad-card p {
-      color: rgba(255, 255, 255, 0.84);
-    }
-    .nomad-points,
-    .nomad-pillars {
-      list-style: none;
-      padding: 0;
-      margin: 1rem 0 0;
-      display: grid;
-      gap: 0.8rem;
-    }
-    .nomad-points li,
-    .nomad-pillars li {
-      padding: 0.8rem 0.95rem;
-      border-radius: 18px;
-      background: rgba(255, 255, 255, 0.06);
-      border: 1px solid rgba(255, 255, 255, 0.1);
-      color: rgba(255, 255, 255, 0.88);
-    }
-    .nomad-pillars strong {
-      display: block;
-      margin-bottom: 0.25rem;
-      color: #d7fff2;
-    }
-    .nomad-actions {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.9rem;
-      margin-top: 1.25rem;
-    }
-    .nomad-link {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.55rem;
-      color: var(--accent);
-      font-weight: 700;
-      text-decoration: none;
-    }
     .partner-card {
       background: rgba(255, 255, 255, 0.12);
       border-radius: 16px;
@@ -1962,56 +1885,6 @@
     </p>
   </section>
 
-  <section id="nomad-system" class="nomad-system-section">
-    <div class="nomad-shell">
-      <div class="nomad-grid">
-        <article class="nomad-card">
-          <span class="nomad-kicker">Nomad system direction</span>
-          <h2>Portable work, open hardware, and a calmer way to build on the move.</h2>
-          <p>
-            3dvr is not only a website and support business. The longer vision is a real nomad system:
-            portable computing, practical gear, Linux-first workflows, and infrastructure that helps
-            people work from more places with less dependence on closed platforms.
-          </p>
-          <ul class="nomad-points">
-            <li>Start with services, setup help, and community that already work today.</li>
-            <li>Grow into gear guidance, workstation kits, and portable infrastructure experiments.</li>
-            <li>Keep the stack open-source, repairable where possible, and useful in the real world.</li>
-          </ul>
-          <div class="nomad-actions">
-            <a class="cta" href="nomad-system.html" data-growth-cta="explore-nomad-system">Explore the nomad system</a>
-            <a class="cta" href="pocket-workstation.html" data-growth-cta="pocket-workstation-page">Pocket Workstation install</a>
-            <a class="nomad-link" href="vision/index.html">
-              Read the broader vision
-              <i class="fa-solid fa-arrow-right" aria-hidden="true"></i>
-            </a>
-          </div>
-        </article>
-        <aside class="nomad-card">
-          <h3>What the stack includes</h3>
-          <ul class="nomad-pillars">
-            <li>
-              <strong>Work</strong>
-              Websites, apps, AI tools, launch help, and support for independent builders.
-            </li>
-            <li>
-              <strong>Device</strong>
-              Linux-powered laptops, portable monitors, input systems, and travel-ready desks.
-            </li>
-            <li>
-              <strong>Power and shelter</strong>
-              Connectivity, solar-ready ideas, lightweight shelter, and real mobile comfort.
-            </li>
-            <li>
-              <strong>Future hardware</strong>
-              Open hardware and low-power computing experiments that point toward deeper independence.
-            </li>
-          </ul>
-        </aside>
-      </div>
-    </div>
-  </section>
-
   <section id="portal" style="background: linear-gradient(135deg, #0f2027, #203a43, #2c5364); text-align: center;">
     <h2>Portal command center</h2>
     <p style="max-width: 820px; margin: 1rem auto 2rem; font-size: 1.15rem; color: #e5f7f3;">
@@ -2026,6 +1899,15 @@
       <div class="card" style="background: rgba(0, 0, 0, 0.35); text-align: left;">
         <h3 style="color: var(--accent);">OS direction</h3>
         <p>Pocket Workstation, Debian Browser Lab, and TommyOS experiments point toward deeper device and hardware control without losing the same system identity.</p>
+      </div>
+      <div class="card" style="background: rgba(0, 0, 0, 0.35); text-align: left;">
+        <h3 style="color: var(--accent);">Nomad system</h3>
+        <p>Portable work, open hardware, Linux-first workflows, and practical gear now live on the dedicated nomad system page.</p>
+        <p style="margin-top: 1rem;">
+          <a href="nomad-system.html" data-growth-cta="explore-nomad-system" style="color: var(--accent); font-weight: 700;">Explore the nomad system</a>
+          <span aria-hidden="true"> · </span>
+          <a href="pocket-workstation.html" data-growth-cta="pocket-workstation-page" style="color: var(--accent); font-weight: 700;">Pocket Workstation install</a>
+        </p>
       </div>
     </div>
     <a class="cta" href="https://portal.3dvr.tech" target="_blank" rel="noopener" style="display: inline-flex; align-items: center; gap: 0.5rem;">

--- a/nomad-system.html
+++ b/nomad-system.html
@@ -313,6 +313,16 @@
       color: var(--muted);
     }
 
+    .direction-points {
+      margin: 1.25rem 0 2rem;
+      padding-left: 1.15rem;
+      color: var(--muted);
+    }
+
+    .direction-points li + li {
+      margin-top: 0.4rem;
+    }
+
     .band {
       background: linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.02));
       border-top: 1px solid rgba(255, 255, 255, 0.07);
@@ -521,12 +531,19 @@
     <section id="system">
       <div class="container">
         <div class="section-title">
-          <h2>The 3dvr nomad system</h2>
+          <h2>Nomad system direction</h2>
           <p>
-            This is the stack we are building over time, starting with what works now
-            and moving toward deeper hardware and infrastructure independence.
+            Portable work, open hardware, and a calmer way to build on the move.
+            3dvr is not only a website and support business. The longer vision is a real nomad system:
+            portable computing, practical gear, Linux-first workflows, and infrastructure that helps
+            people work from more places with less dependence on closed platforms.
           </p>
         </div>
+        <ul class="direction-points">
+          <li>Start with services, setup help, and community that already work today.</li>
+          <li>Grow into gear guidance, workstation kits, and portable infrastructure experiments.</li>
+          <li>Keep the stack open-source, repairable where possible, and useful in the real world.</li>
+        </ul>
         <div class="grid-4">
           <article class="card">
             <h3>1. Work</h3>

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -89,12 +89,12 @@ describe('3dvr-web customer journey copy', () => {
     assert.doesNotMatch(html, /Start free in portal/);
     assert.doesNotMatch(html, /Not just plan\. Not just think about it\./);
     assert.doesNotMatch(html, /Open the full-screen 3DVR world prototype/);
-    assert.match(html, /Nomad system direction/);
-    assert.match(html, /Portable work, open hardware, and a calmer way to build on the move\./);
+    assert.match(html, /Nomad system/);
+    assert.match(html, /Portable work, open hardware, Linux-first workflows, and practical gear now live on the dedicated nomad system page\./);
     assert.match(html, /Explore the nomad system/);
-    assert.match(html, /Read the broader vision/);
     assert.match(html, /href="nomad-system\.html"/);
-    assert.match(html, /What the stack includes/);
+    assert.doesNotMatch(html, /Nomad system direction/);
+    assert.doesNotMatch(html, /What the stack includes/);
     assert.match(html, /Portal command center/);
     assert.match(html, /Start in the browser with one identity, one launcher, and one calmer operating lane\./);
     assert.match(html, /Portal layer/);
@@ -254,7 +254,9 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /Live anywhere\./);
     assert.match(html, /Build anything\./);
     assert.match(html, /Open-source ecology for digital nomads/);
-    assert.match(html, /The 3dvr nomad system/);
+    assert.match(html, /Nomad system direction/);
+    assert.match(html, /Portable work, open hardware, and a calmer way to build on the move\./);
+    assert.match(html, /The longer vision is a real nomad system/);
     assert.match(html, /What we're offering first/);
     assert.match(html, /Start with membership/);
     assert.match(html, /See membership options/);


### PR DESCRIPTION
## What changed

- Removed the full Nomad system direction block from the homepage.
- Added a compact Nomad system handoff card inside the existing Portal command center section, keeping links to `nomad-system.html` and `pocket-workstation.html`.
- Moved the fuller direction copy into `nomad-system.html` under its system section.
- Updated customer journey coverage to assert the homepage is a concise handoff and the dedicated page owns the longer nomad copy.

## Why

The homepage was carrying another long strategic section after the Portal / Browser / OS block was moved out. This keeps the homepage shorter while preserving a clear path to the detailed nomad system page.

## Validation

- Passed: `node --test tests/customer-journey.test.js tests/install-script.test.js`
- Passed: `npm run test:unit`
- Passed local HTTP smoke checks for `/` and `/nomad-system.html`. The local server returns 404 for `/_vercel/insights/script.js`, which is expected outside Vercel.