### PR TITLE
[codex] Remove internal auto-business link from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1621,9 +1621,6 @@
 
   <section id="subscribe" style="background: var(--bg-subscribe);">
     <h2>Simple ways to work together</h2>
-    <p class="section-lede">
-      Internal offer notes: <a href="auto-business/">auto-business design document</a>.
-    </p>
     <div class="card-grid">
       <a
         class="card"

--- a/tests/auto-business.test.js
+++ b/tests/auto-business.test.js
@@ -53,13 +53,15 @@ describe('3DVR auto-business design document', () => {
     assert.match(html, /data-portal-path="\/billing\/\?plan=custom"/);
   });
 
-  it('keeps the homepage link low-key and removes the route from the sitemap', async () => {
+  it('keeps the internal route off the public homepage and sitemap', async () => {
     const homeHtml = await readFile(new URL('../index.html', import.meta.url), 'utf8');
     const sitemap = await readFile(new URL('../sitemap.xml', import.meta.url), 'utf8');
 
     assert.match(homeHtml, /href="#subscribe">Plans<\/a>/);
     assert.match(homeHtml, /href="#subscribe">\s*See plans\s*<\/a>/);
-    assert.match(homeHtml, /Internal offer notes: <a href="auto-business\/">auto-business design document<\/a>/);
+    assert.doesNotMatch(homeHtml, /Internal offer notes/);
+    assert.doesNotMatch(homeHtml, /auto-business design document/);
+    assert.doesNotMatch(homeHtml, /href="auto-business\/"/);
     assert.doesNotMatch(homeHtml, /href="auto-business\/">Plans<\/a>/);
     assert.doesNotMatch(homeHtml, /href="auto-business\/">\s*See plans\s*<\/a>/);
     assert.doesNotMatch(homeHtml, /Open plans and project sprints/);


### PR DESCRIPTION
## What changed

- Removed the public homepage line linking to the internal auto-business design document from the plans section.
- Updated auto-business coverage so the internal route remains available directly, but stays off the homepage and sitemap.

## Why

The auto-business page is an internal/noindex design document. Keeping its link in the public plans section made the homepage feel less customer-facing after the other strategic sections were moved out.

## Validation

- Passed: `node --test tests/auto-business.test.js tests/customer-journey.test.js`
- Passed: `npm run test:unit`
- Passed local HTTP smoke checks for `/` and `/auto-business/`. The local server returns 404 for `/_vercel/insights/script.js`, which is expected outside Vercel.