### PR TITLE
[codex] Update homepage hero copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -1505,7 +1505,7 @@
             <strong>3dvr<span>.tech</span></strong>
           </div>
           <p>
-            A clear place to land when you need a site, support, or a launch plan.
+            Build the future.
           </p>
         </div>
       </div>

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -16,7 +16,7 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /Start Free/);
     assert.match(html, /Start a project/);
     assert.match(html, /Launch in 3 Days/);
-    assert.match(html, /A clear place to land when you need a site, support, or a launch plan\./);
+    assert.match(html, /Build the future\./);
     assert.match(html, /data-portal-path="\/start\/"/);
     assert.match(html, /data-portal-path="\/free-trial\.html"/);
     assert.match(html, /data-portal-path="\/billing\/\?plan=starter"/);
@@ -70,7 +70,7 @@ describe('3dvr-web customer journey copy', () => {
     assert.doesNotMatch(html, /Best for support teams, organizations, and shared workflows that need one calmer operating lane\./);
     assert.doesNotMatch(html, /\$20 starting point/);
     assert.doesNotMatch(html, /See the launch flow/);
-    assert.match(html, /A clear place to land when you need a site, support, or a launch plan\./);
+    assert.match(html, /Build the future\./);
     assert.doesNotMatch(html, /Websites\. Apps\. Real support\./);
     assert.doesNotMatch(html, /A real place to land when you need a site, support, or a launch plan\./);
     assert.doesNotMatch(html, /Best for real businesses that need a site, follow-up, updates, and calmer operations\./);

--- a/tests/homepage-growth.test.js
+++ b/tests/homepage-growth.test.js
@@ -17,7 +17,7 @@ test('homepage ships Gun-backed experiment and focused CTA plumbing', async () =
   assert.match(html, /data-growth-cta="start-project-primary"/);
   assert.match(html, /data-growth-cta="see-plans"/);
   assert.match(html, /class="hero-logo-card(?:\s|")/);
-  assert.match(html, /A clear place to land when you need a site, support, or a launch plan\./);
+  assert.match(html, /Build the future\./);
   assert.doesNotMatch(html, /data-growth-cta="enter-3dvr-world"/);
   assert.match(html, /class="plan-lane-section"/);
   assert.match(html, /data-growth-cta="plan-free"/);


### PR DESCRIPTION
## What changed

- Replaces the homepage line "A clear place to land when you need a site, support, or a launch plan." with "Build the future."
- Updates homepage copy tests to match the new text.

## Validation

- `npm run test:unit` passed.