### PR TITLE
[codex] Emphasize homepage build future tagline

### DIFF
--- a/index.html
+++ b/index.html
@@ -819,6 +819,12 @@
       color: rgba(255,255,255,0.75);
       margin: 0;
     }
+    .hero-logo-card__tagline {
+      font-size: clamp(1.35rem, 3.2vw, 2rem);
+      font-weight: 800;
+      line-height: 1.05;
+      color: rgba(255,255,255,0.92);
+    }
     .hero-logo-card__enter {
       display: inline-flex;
       align-items: center;
@@ -1504,8 +1510,8 @@
             </div>
             <strong>3dvr<span>.tech</span></strong>
           </div>
-          <p>
-            Build the future.
+          <p class="hero-logo-card__tagline">
+            Build the future
           </p>
         </div>
       </div>

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -16,7 +16,8 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /Start Free/);
     assert.match(html, /Start a project/);
     assert.match(html, /Launch in 3 Days/);
-    assert.match(html, /Build the future\./);
+    assert.match(html, /Build the future/);
+    assert.doesNotMatch(html, /Build the future\./);
     assert.match(html, /data-portal-path="\/start\/"/);
     assert.match(html, /data-portal-path="\/free-trial\.html"/);
     assert.match(html, /data-portal-path="\/billing\/\?plan=starter"/);
@@ -70,7 +71,8 @@ describe('3dvr-web customer journey copy', () => {
     assert.doesNotMatch(html, /Best for support teams, organizations, and shared workflows that need one calmer operating lane\./);
     assert.doesNotMatch(html, /\$20 starting point/);
     assert.doesNotMatch(html, /See the launch flow/);
-    assert.match(html, /Build the future\./);
+    assert.match(html, /Build the future/);
+    assert.doesNotMatch(html, /Build the future\./);
     assert.doesNotMatch(html, /Websites\. Apps\. Real support\./);
     assert.doesNotMatch(html, /A real place to land when you need a site, support, or a launch plan\./);
     assert.doesNotMatch(html, /Best for real businesses that need a site, follow-up, updates, and calmer operations\./);

--- a/tests/homepage-growth.test.js
+++ b/tests/homepage-growth.test.js
@@ -17,7 +17,8 @@ test('homepage ships Gun-backed experiment and focused CTA plumbing', async () =
   assert.match(html, /data-growth-cta="start-project-primary"/);
   assert.match(html, /data-growth-cta="see-plans"/);
   assert.match(html, /class="hero-logo-card(?:\s|")/);
-  assert.match(html, /Build the future\./);
+  assert.match(html, /Build the future/);
+  assert.doesNotMatch(html, /Build the future\./);
   assert.doesNotMatch(html, /data-growth-cta="enter-3dvr-world"/);
   assert.match(html, /class="plan-lane-section"/);
   assert.match(html, /data-growth-cta="plan-free"/);


### PR DESCRIPTION
## What changed

- Removes the period from the homepage hero tagline so it reads `Build the future`.
- Adds a targeted tagline class to make that line larger and bold without affecting other hero copy.
- Updates homepage copy tests to require the no-period version.

## Validation

- `npm run test:unit` passed.