### PR TITLE
[codex] Update homepage plan lane copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -1541,7 +1541,7 @@
 
   <section class="plan-lane-section" aria-labelledby="planLaneTitle">
     <div class="plan-lane-dock" aria-label="Quick plan links">
-      <h2 id="planLaneTitle" class="plan-lane-title">Pick the lane that fits.</h2>
+      <h2 id="planLaneTitle" class="plan-lane-title">Start free, or choose the lane that fits</h2>
       <p class="plan-lane-dock__intro">
         Start free if you are still organizing, or choose the lane that matches the support you need.
       </p>
@@ -1553,7 +1553,7 @@
           href="https://portal.3dvr.tech/free-trial.html"
         >
           <strong>Free</strong>
-          <span>Get organized first</span>
+          <span>Get Organized</span>
         </a>
         <a
           class="plan-lane-chip"
@@ -1571,7 +1571,7 @@
           href="https://portal.3dvr.tech/billing/?plan=pro"
         >
           <strong>$20</strong>
-          <span>Launch in 3 Days</span>
+          <span>Launch now!</span>
         </a>
         <a
           class="plan-lane-chip"

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -15,7 +15,7 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /Launch a site, offer, or simple business system with direct support from idea to live\./);
     assert.match(html, /Start Free/);
     assert.match(html, /Start a project/);
-    assert.match(html, /Launch in 3 Days/);
+    assert.match(html, /Launch now!/);
     assert.match(html, /Build the future/);
     assert.doesNotMatch(html, /Build the future\./);
     assert.match(html, /data-portal-path="\/start\/"/);
@@ -25,10 +25,11 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /data-portal-path="\/billing\/\?plan=builder"/);
     assert.match(html, /data-portal-path="\/billing\/\?plan=embedded"/);
     assert.doesNotMatch(html, /Plans after the offer is clear/);
-    assert.match(html, /Pick the lane that fits\./);
-    assert.match(html, /Get organized first/);
+    assert.match(html, /Start free, or choose the lane that fits/);
+    assert.doesNotMatch(html, /Pick the lane that fits\./);
+    assert.match(html, /Get Organized/);
     assert.match(html, /Light monthly support/);
-    assert.match(html, /Launch in 3 Days/);
+    assert.match(html, /Launch now!/);
     assert.match(html, /Default for businesses/);
     assert.match(html, /Run one calmer team system/);
     assert.match(html, /One-time payment or deposit/);

--- a/tests/life-plan.test.js
+++ b/tests/life-plan.test.js
@@ -7,7 +7,7 @@ test('free plan copy points to the portal start path in plain language', async (
   const plansHtml = await readFile(new URL('../subscribe/index.html', import.meta.url), 'utf8');
   const freeHtml = await readFile(new URL('../subscribe/free-plan.html', import.meta.url), 'utf8');
 
-  assert.match(homeHtml, /Pick the lane that fits\./);
+  assert.match(homeHtml, /Start free, or choose the lane that fits/);
   assert.match(homeHtml, /Light monthly support/);
   assert.match(plansHtml, /Get organized, sort out your next steps, and start using the portal without paying first\./);
   assert.match(plansHtml, /Daily check-ins and weekly reflection/);


### PR DESCRIPTION
## What changed

- Changes the plan-lane heading to `Start free, or choose the lane that fits`.
- Updates the Free card helper text to `Get Organized`.
- Updates the $20 card helper text to `Launch now!`.
- Updates tests to match the new homepage copy.

## Validation

- `npm run test:unit` passed.