### PR TITLE
[codex] Increase build future tagline emphasis

### DIFF
--- a/index.html
+++ b/index.html
@@ -820,8 +820,8 @@
       margin: 0;
     }
     .hero-logo-card__tagline {
-      font-size: clamp(1.35rem, 3.2vw, 2rem);
-      font-weight: 800;
+      font-size: clamp(1.65rem, 4vw, 2.45rem);
+      font-weight: 900;
       line-height: 1.05;
       color: rgba(255,255,255,0.92);
     }


### PR DESCRIPTION
## What changed

- Makes the homepage `Build the future` tagline larger.
- Raises the tagline font weight from 800 to 900.

## Validation

- `npm run test:unit` passed.