### PR TITLE
[codex] Tune homepage feature grid and tagline

### DIFF
--- a/index.html
+++ b/index.html
@@ -820,10 +820,10 @@
       margin: 0;
     }
     .hero-logo-card__tagline {
-      font-size: clamp(1.65rem, 4vw, 2.45rem);
+      font-size: clamp(2rem, 5vw, 3.1rem);
       font-weight: 900;
-      line-height: 1.05;
-      color: rgba(255,255,255,0.92);
+      line-height: 0.98;
+      color: rgba(255,255,255,0.96);
     }
     .hero-logo-card__enter {
       display: inline-flex;
@@ -983,9 +983,9 @@
       position: relative;
       z-index: 1;
       display: grid;
-      grid-template-columns: repeat(5, minmax(0, 1fr));
+      grid-template-columns: repeat(3, minmax(0, 1fr));
       gap: clamp(0.9rem, 1.5vw, 1.25rem);
-      width: min(1400px, calc(100% - 2rem));
+      width: min(980px, calc(100% - 2rem));
     }
     .feature-card {
       width: 100%;
@@ -1072,10 +1072,10 @@
     }
     .feature-card:hover .feature-cta { color: #f9f9f9; }
 
-    @media (max-width: 1180px) {
+    @media (min-width: 1500px) {
       .features-grid {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        width: min(980px, calc(100% - 2rem));
+        grid-template-columns: repeat(5, minmax(0, 1fr));
+        width: min(1400px, calc(100% - 2rem));
       }
     }
     @media (max-width: 760px) {

--- a/tests/homepage-growth.test.js
+++ b/tests/homepage-growth.test.js
@@ -24,6 +24,7 @@ test('homepage ships Gun-backed experiment and focused CTA plumbing', async () =
   assert.match(html, /data-growth-cta="plan-free"/);
   assert.match(html, /data-growth-cta="plan-starter"/);
   assert.match(html, /grid-template-columns:\s*repeat\(3,\s*minmax\(0,\s*1fr\)\)/);
+  assert.match(html, /@media \(min-width:\s*1500px\)\s*{\s*\.features-grid\s*{\s*grid-template-columns:\s*repeat\(5,\s*minmax\(0,\s*1fr\)\)/);
   assert.match(html, /data-growth-cta="sticky-start-free"[^>]+data-portal-path="\/free-trial\.html"/);
   assert.match(html, /data-growth-cta="start-project-primary"[^>]+data-portal-path="\/start\/"/);
   assert.match(html, /data-growth-cta="plan-free"[^>]+data-portal-path="\/free-trial\.html"/);


### PR DESCRIPTION
## What changed

- Makes `Build the future` larger, tighter, and brighter in the homepage hero card.
- Changes the Practical Help grid default from 5-up to 3 columns so five cards lay out as 3/2 on normal laptop screens.
- Keeps the 5-up Practical Help layout only for very wide screens at 1500px and above.
- Adds a focused test assertion for the wide-screen feature grid breakpoint.

## Validation

- `npm run test:unit` passed.