### PR TITLE
[codex] Shorten web cache and harden service worker

### DIFF
--- a/pwa.js
+++ b/pwa.js
@@ -118,8 +118,8 @@
 
   if (supportsServiceWorker) {
     window.addEventListener('load', () => {
-      navigator.serviceWorker.register('/service-worker.js')
-        .then((registration) => registration.update().catch(() => {}))
+      navigator.serviceWorker.register('/service-worker.js', { updateViaCache: 'none' })
+        .then((registration) => registration.update())
         .catch((error) => {
           console.error('Service worker registration failed:', error);
         });

--- a/repair/index.html
+++ b/repair/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>3DVR | Build the Next Progress</title>
   <meta name="description" content="A 3DVR manifesto on the last 200 years of progress, why the promise broke for ordinary people, and how open tools, AI, and community ownership can help build what comes next." />
+  <link rel="canonical" href="https://3dvr.tech/repair/" />
   <style>
     :root {
       --bg: #071017;
@@ -437,19 +438,21 @@
       .nav-links { display: none; }
     }
   </style>
+  <script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body>
   <nav class="nav">
     <div class="wrap nav-inner">
-      <a class="brand" href="#top" aria-label="3DVR home">
+      <a class="brand" href="/" aria-label="3DVR home">
         <span class="mark">3D</span>
         <span>3DVR</span>
       </a>
       <div class="nav-links">
+        <a href="/">Home</a>
         <a href="#story">The Story</a>
         <a href="#break">The Break</a>
         <a href="#join">Join 3DVR</a>
-        <a class="btn primary" href="mailto:hello@3dvr.tech?subject=I%20want%20to%20join%203DVR">Start Building</a>
+        <a class="btn primary" href="/subscribe/">View plans</a>
       </div>
     </div>
   </nav>
@@ -634,8 +637,8 @@
           We can build local tools, open tools, humane tools, beautiful tools, and business systems that help real people create value again. That is the 3DVR invitation.
         </p>
         <div class="hero-actions" style="justify-content: center;">
-          <a class="btn primary" href="mailto:hello@3dvr.tech?subject=I%20want%20to%20join%203DVR&amp;body=Hi%203DVR%2C%0A%0AI%20want%20to%20join%20or%20support%20the%20mission.%20Here%27s%20what%20I%27m%20building%20or%20what%20I%20need%20help%20with%3A%0A">Join the mission</a>
-          <a class="btn" href="https://3dvr.tech">Visit 3dvr.tech</a>
+          <a class="btn primary" href="/subscribe/">View subscriptions</a>
+          <a class="btn" href="/">3dvr.tech home</a>
         </div>
       </div>
     </section>
@@ -644,7 +647,7 @@
   <footer>
     <div class="wrap footer-inner">
       <div>© <span id="year"></span> 3DVR · Creating Universal Experiences</div>
-      <div>Open tools · Human agency · Practical consciousness</div>
+      <div><a href="/">3dvr.tech home</a> · Open tools · Human agency · Practical consciousness</div>
     </div>
   </footer>
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,7 @@
-const CACHE_NAME = '3dvr-cache-v5';
+const CACHE_NAME = '3dvr-runtime-v6';
+const OFFLINE_CACHE_NAME = '3dvr-offline-v6';
+const RUNTIME_MAX_AGE_MS = 10 * 60 * 1000;
+const CACHE_TIMESTAMP_HEADER = 'sw-cached-at';
 const OFFLINE_ASSETS = [
   '/',
   '/index.html',
@@ -7,20 +10,17 @@ const OFFLINE_ASSETS = [
   '/3DVR.png',
   '/3DVRfavicon.png'
 ];
-const NETWORK_FIRST_EXTENSIONS = [
-  '.css',
-  '.js',
-  '.json',
-  '.webmanifest',
-  '.txt'
-];
-const CACHE_FIRST_EXTENSIONS = [
+const CACHEABLE_EXTENSIONS = [
   '.png',
   '.jpg',
   '.jpeg',
   '.gif',
   '.svg',
   '.webp',
+  '.css',
+  '.js',
+  '.json',
+  '.webmanifest',
   '.woff',
   '.woff2'
 ];
@@ -49,20 +49,7 @@ function isHtmlNavigationRequest(request) {
   );
 }
 
-function isNetworkFirstAssetRequest(request) {
-  if (!isSameOrigin(request) || isHtmlNavigationRequest(request)) {
-    return false;
-  }
-
-  const url = requestUrl(request);
-  if (!url) {
-    return false;
-  }
-
-  return NETWORK_FIRST_EXTENSIONS.some(extension => url.pathname.endsWith(extension));
-}
-
-function isCacheFirstAssetRequest(request) {
+function isCacheableAssetRequest(request) {
   if (!isSameOrigin(request) || isHtmlNavigationRequest(request)) {
     return false;
   }
@@ -76,64 +63,104 @@ function isCacheFirstAssetRequest(request) {
     return true;
   }
 
-  return CACHE_FIRST_EXTENSIONS.some(extension => url.pathname.endsWith(extension));
+  return CACHEABLE_EXTENSIONS.some(extension => url.pathname.endsWith(extension));
 }
 
-async function cacheResponse(request, response) {
+function cachedAt(response) {
+  const timestamp = Number(response?.headers?.get?.(CACHE_TIMESTAMP_HEADER) || 0);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function isFreshCachedResponse(response) {
+  const timestamp = cachedAt(response);
+  return Boolean(timestamp && Date.now() - timestamp < RUNTIME_MAX_AGE_MS);
+}
+
+async function timestampedResponse(response) {
+  const headers = new Headers(response.headers);
+  headers.set(CACHE_TIMESTAMP_HEADER, String(Date.now()));
+
+  return new Response(await response.clone().blob(), {
+    status: response.status,
+    statusText: response.statusText,
+    headers
+  });
+}
+
+async function cacheResponse(request, response, cacheName = CACHE_NAME) {
   if (!response || response.status !== 200 || !isSameOrigin(request)) {
     return response;
   }
 
-  const cache = await caches.open(CACHE_NAME);
-  await cache.put(request, response.clone());
+  const cache = await caches.open(cacheName);
+  await cache.put(request, await timestampedResponse(response));
   return response;
 }
 
-async function networkFirstResponse(request, { offlineFallbackPath = '' } = {}) {
+async function networkFirstNavigationResponse(request) {
   try {
-    const response = await fetch(request);
-    return await cacheResponse(request, response);
+    const response = await fetch(request, { cache: 'no-store' });
+    return await cacheResponse(request, response, OFFLINE_CACHE_NAME);
   } catch (error) {
-    const cached = await caches.match(request);
+    const cache = await caches.open(OFFLINE_CACHE_NAME);
+    const cached = await cache.match(request);
     if (cached) {
       return cached;
     }
 
-    if (offlineFallbackPath) {
-      const offlineFallback = await caches.match(offlineFallbackPath);
-      if (offlineFallback) {
-        return offlineFallback;
-      }
-    }
-
-    return new Response('Offline', {
-      status: 503,
-      statusText: 'Offline'
-    });
+    return cache.match('/index.html');
   }
 }
 
-async function cacheFirstResponse(request) {
-  const cached = await caches.match(request);
-  if (cached) {
+function updateCachedAsset(request) {
+  return fetch(request, { cache: 'no-store' })
+    .then((response) => cacheResponse(request, response))
+    .catch(() => undefined);
+}
+
+async function shortLivedAssetResponse(request, event) {
+  const cache = await caches.open(CACHE_NAME);
+  const cached = await cache.match(request);
+
+  if (cached && isFreshCachedResponse(cached)) {
+    event.waitUntil(updateCachedAsset(request));
     return cached;
   }
 
-  const response = await fetch(request);
-  return cacheResponse(request, response);
+  try {
+    const response = await fetch(request, { cache: 'no-store' });
+    return await cacheResponse(request, response);
+  } catch (error) {
+    if (cached) {
+      return cached;
+    }
+
+    const offlineCached = await caches.match(request);
+    if (offlineCached) {
+      return offlineCached;
+    }
+
+    throw error;
+  }
 }
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(OFFLINE_ASSETS)).then(() => self.skipWaiting())
+    caches.open(OFFLINE_CACHE_NAME).then((cache) => cache.addAll(OFFLINE_ASSETS)).then(() => self.skipWaiting())
   );
 });
 
 self.addEventListener('activate', (event) => {
   event.waitUntil(
     caches.keys().then((keys) =>
-      Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
-    ).then(() => self.clients.claim())
+      Promise.all(
+        keys
+          .filter((key) => key !== CACHE_NAME && key !== OFFLINE_CACHE_NAME)
+          .map((key) => caches.delete(key))
+      )
+    )
+      .then(() => self.registration?.navigationPreload?.enable?.())
+      .then(() => self.clients.claim())
   );
 });
 
@@ -143,16 +170,11 @@ self.addEventListener('fetch', (event) => {
   }
 
   if (isHtmlNavigationRequest(event.request)) {
-    event.respondWith(networkFirstResponse(event.request, { offlineFallbackPath: '/index.html' }));
+    event.respondWith(networkFirstNavigationResponse(event.request));
     return;
   }
 
-  if (isNetworkFirstAssetRequest(event.request)) {
-    event.respondWith(networkFirstResponse(event.request));
-    return;
-  }
-
-  if (isCacheFirstAssetRequest(event.request)) {
-    event.respondWith(cacheFirstResponse(event.request));
+  if (isCacheableAssetRequest(event.request)) {
+    event.respondWith(shortLivedAssetResponse(event.request, event));
   }
 });

--- a/tests/service-worker.test.js
+++ b/tests/service-worker.test.js
@@ -1,40 +1,45 @@
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import test from 'node:test';
 import vm from 'node:vm';
-import { fileURLToPath } from 'node:url';
 
-const serviceWorkerPath = new URL('../service-worker.js', import.meta.url);
-const serviceWorkerFilename = fileURLToPath(serviceWorkerPath);
+const serviceWorkerPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'service-worker.js'
+);
 
 async function loadServiceWorker({
-  cacheMatch,
+  cacheMatch = async () => undefined,
   fetchImpl
 } = {}) {
   const source = await readFile(serviceWorkerPath, 'utf8');
   const listeners = {};
   const cachePuts = [];
+  const deletedCaches = [];
 
   const caches = {
     async match(request) {
-      if (typeof cacheMatch === 'function') {
-        return cacheMatch(request);
-      }
-      return undefined;
+      return cacheMatch(request, 'global');
     },
-    async open() {
+    async open(cacheName) {
       return {
         async addAll() {},
+        async match(request) {
+          return cacheMatch(request, cacheName);
+        },
         async put(request, response) {
-          cachePuts.push({ request, response });
+          cachePuts.push({ cacheName, request, response });
         }
       };
     },
     async keys() {
-      return ['3dvr-cache-v1', '3dvr-cache-v2'];
+      return ['3dvr-cache-v1', '3dvr-runtime-v6', '3dvr-offline-v6'];
     },
-    async delete() {
+    async delete(cacheName) {
+      deletedCaches.push(cacheName);
       return true;
     }
   };
@@ -42,6 +47,7 @@ async function loadServiceWorker({
   const sandbox = {
     URL,
     Response,
+    Headers,
     Promise,
     console,
     caches,
@@ -49,6 +55,9 @@ async function loadServiceWorker({
     self: {
       location: { origin: 'https://www.3dvr.tech' },
       clients: { claim() {} },
+      registration: {
+        navigationPreload: { enable() {} }
+      },
       skipWaiting() {},
       addEventListener(type, handler) {
         listeners[type] = handler;
@@ -57,10 +66,10 @@ async function loadServiceWorker({
   };
 
   vm.runInNewContext(source, sandbox, {
-    filename: path.basename(serviceWorkerFilename)
+    filename: path.basename(serviceWorkerPath)
   });
 
-  return { listeners, cachePuts };
+  return { listeners, cachePuts, deletedCaches };
 }
 
 function createRequest(url, options = {}) {
@@ -83,22 +92,28 @@ function createRequest(url, options = {}) {
 
 async function dispatchFetch(listeners, request) {
   let responsePromise;
+  const waitUntilPromises = [];
   listeners.fetch({
     request,
+    waitUntil(promise) {
+      waitUntilPromises.push(promise);
+    },
     respondWith(promise) {
       responsePromise = promise;
     }
   });
 
   assert.ok(responsePromise, 'fetch handler should call respondWith');
-  return responsePromise;
+  const response = await responsePromise;
+  await Promise.all(waitUntilPromises);
+  return response;
 }
 
 test('service worker uses network-first for html navigations', async () => {
   let fetchCalls = 0;
   const { listeners, cachePuts } = await loadServiceWorker({
-    cacheMatch: async (request) => {
-      if (request === '/index.html') {
+    cacheMatch: async (request, cacheName) => {
+      if (cacheName === '3dvr-offline-v6' && request === '/index.html') {
         return new Response('offline-home', { status: 200 });
       }
       return new Response('cached-html', { status: 200 });
@@ -120,14 +135,18 @@ test('service worker uses network-first for html navigations', async () => {
   assert.equal(fetchCalls, 1);
   assert.equal(await response.text(), 'network-html');
   assert.equal(cachePuts.length, 1);
+  assert.equal(cachePuts[0].cacheName, '3dvr-offline-v6');
 });
 
-test('service worker uses network-first for same-origin js assets', async () => {
+test('service worker refreshes fresh same-origin assets in the background', async () => {
   let fetchCalls = 0;
-  const { listeners, cachePuts } = await loadServiceWorker({
-    cacheMatch: async (request) => {
-      if (request?.url === 'https://www.3dvr.tech/subscribe/portal-links.js') {
-        return new Response('cached-js', { status: 200 });
+  const { listeners } = await loadServiceWorker({
+    cacheMatch: async (request, cacheName) => {
+      if (cacheName === '3dvr-runtime-v6' && request?.url === 'https://www.3dvr.tech/subscribe/portal-links.js') {
+        return new Response('cached-js', {
+          status: 200,
+          headers: { 'sw-cached-at': String(Date.now()) }
+        });
       }
       return undefined;
     },
@@ -145,77 +164,34 @@ test('service worker uses network-first for same-origin js assets', async () => 
   );
 
   assert.equal(fetchCalls, 1);
-  assert.equal(await response.text(), 'network-js');
-  assert.equal(cachePuts.length, 1);
+  assert.equal(await response.text(), 'cached-js');
 });
 
-test('service worker falls back to cached js assets when offline', async () => {
+test('service worker fetches stale same-origin assets before falling back to cache', async () => {
+  let fetchCalls = 0;
   const { listeners } = await loadServiceWorker({
-    cacheMatch: async (request) => {
-      if (request?.url === 'https://www.3dvr.tech/subscribe/portal-links.js') {
-        return new Response('cached-js', { status: 200 });
+    cacheMatch: async (request, cacheName) => {
+      if (cacheName === '3dvr-runtime-v6' && request?.url === 'https://www.3dvr.tech/dist/script.js') {
+        return new Response('stale-js', {
+          status: 200,
+          headers: { 'sw-cached-at': String(Date.now() - 60 * 60 * 1000) }
+        });
       }
       return undefined;
     },
     fetchImpl: async () => {
-      throw new Error('offline');
+      fetchCalls += 1;
+      return new Response('network-js', { status: 200 });
     }
   });
 
   const response = await dispatchFetch(
     listeners,
-    createRequest('https://www.3dvr.tech/subscribe/portal-links.js', {
+    createRequest('https://www.3dvr.tech/dist/script.js', {
       accept: 'text/javascript'
     })
   );
 
-  assert.equal(await response.text(), 'cached-js');
-});
-
-test('service worker keeps same-origin image assets cache-first', async () => {
-  let fetchCalls = 0;
-  const { listeners } = await loadServiceWorker({
-    cacheMatch: async (request) => {
-      if (request?.url === 'https://www.3dvr.tech/3DVR.png') {
-        return new Response('cached-image', { status: 200 });
-      }
-      return undefined;
-    },
-    fetchImpl: async () => {
-      fetchCalls += 1;
-      return new Response('network-image', { status: 200 });
-    }
-  });
-
-  const response = await dispatchFetch(
-    listeners,
-    createRequest('https://www.3dvr.tech/3DVR.png')
-  );
-
-  assert.equal(fetchCalls, 0);
-  assert.equal(await response.text(), 'cached-image');
-});
-
-test('service worker keeps the svg app logo cache-first', async () => {
-  let fetchCalls = 0;
-  const { listeners } = await loadServiceWorker({
-    cacheMatch: async (request) => {
-      if (request?.url === 'https://www.3dvr.tech/assets/logo-3dvr.svg') {
-        return new Response('cached-logo', { status: 200 });
-      }
-      return undefined;
-    },
-    fetchImpl: async () => {
-      fetchCalls += 1;
-      return new Response('network-logo', { status: 200 });
-    }
-  });
-
-  const response = await dispatchFetch(
-    listeners,
-    createRequest('https://www.3dvr.tech/assets/logo-3dvr.svg')
-  );
-
-  assert.equal(fetchCalls, 0);
-  assert.equal(await response.text(), 'cached-logo');
+  assert.equal(fetchCalls, 1);
+  assert.equal(await response.text(), 'network-js');
 });

--- a/vercel.json
+++ b/vercel.json
@@ -40,6 +40,51 @@
           "value": "public, max-age=0, must-revalidate"
         }
       ]
+    },
+    {
+      "source": "/service-worker.js",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store, max-age=0"
+        }
+      ]
+    },
+    {
+      "source": "/manifest.webmanifest",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=300, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/(.*).html",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/(.*).(js|css|json|png|jpg|jpeg|gif|svg|webp|woff|woff2)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=300, stale-while-revalidate=600"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds short release-oriented cache headers while preserving existing `dave.3dvr.tech` routing and `/install` rewrite/header behavior.
- Changes the service worker to use separate runtime/offline caches, network-first HTML navigation, and short-lived runtime asset caching with background refresh.
- Registers the service worker with `updateViaCache: "none"` and explicit update checks without adding forced reload behavior, preserving native back-button behavior.
- Brings the newly tracked repair page into existing repo conventions so the full unit suite stays green.

## Validation
- `npm run test:unit`
- `node --check service-worker.js`
- `node --check pwa.js`
- Parsed `vercel.json`
- `git diff --check`