### PR TITLE
[codex] Serve public service worker without cache

### DIFF
--- a/tests/vercel-config.test.js
+++ b/tests/vercel-config.test.js
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('service worker header overrides generic js caching', async () => {
+  const config = JSON.parse(await readFile(new URL('../vercel.json', import.meta.url), 'utf8'));
+  const headers = Array.isArray(config.headers) ? config.headers : [];
+  const genericAssetIndex = headers.findIndex((rule) =>
+    rule.source === '/(.*).(js|css|json|png|jpg|jpeg|gif|svg|webp|woff|woff2)'
+  );
+  const serviceWorkerIndex = headers.findIndex((rule) => rule.source === '/service-worker.js');
+  const serviceWorkerRule = headers[serviceWorkerIndex];
+  const cacheControl = serviceWorkerRule?.headers?.find((header) => header.key === 'Cache-Control')?.value;
+
+  assert.ok(genericAssetIndex > -1);
+  assert.ok(serviceWorkerIndex > genericAssetIndex);
+  assert.equal(cacheControl, 'no-store, max-age=0');
+});

--- a/vercel.json
+++ b/vercel.json
@@ -42,15 +42,6 @@
       ]
     },
     {
-      "source": "/service-worker.js",
-      "headers": [
-        {
-          "key": "Cache-Control",
-          "value": "no-store, max-age=0"
-        }
-      ]
-    },
-    {
       "source": "/manifest.webmanifest",
       "headers": [
         {
@@ -83,6 +74,15 @@
         {
           "key": "Cache-Control",
           "value": "public, max-age=300, stale-while-revalidate=600"
+        }
+      ]
+    },
+    {
+      "source": "/service-worker.js",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store, max-age=0"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Move the `/service-worker.js` Vercel header after the broad JS/CSS asset header so it overrides the generic asset cache policy.
- Add config coverage that keeps the service worker on `Cache-Control: no-store, max-age=0`.

## Context
After PR #232, the live service-worker content deployed correctly, but Vercel still served it with the generic `public, max-age=300, stale-while-revalidate=600` header because the broad JS rule matched after the specific service-worker rule. This makes browser-check fixes roll out slower than intended.

## Validation
- `node --test tests/service-worker.test.js tests/vercel-config.test.js`
- `node --check service-worker.js`