### PR TITLE
[codex] Shorten homepage launch copy

### DIFF
--- a/growth/homepage-experiment.js
+++ b/growth/homepage-experiment.js
@@ -31,7 +31,7 @@
       key: 'traction',
       eyebrow: 'Launch fast. Start selling.',
       primary: 'Get your project live.',
-      body: '3dvr helps small businesses and creators launch pages, apps, and follow-up systems without getting stuck in tech.',
+      body: '3dvr helps small businesses and creators launch without getting stuck in tech.',
     }),
   });
 


### PR DESCRIPTION
## Summary
- Shortens the homepage traction variant copy to say creators launch without getting stuck in tech.

## Validation
- `node --test tests/homepage-growth.test.js`