### PR TITLE
[codex] Remove plan lane intro copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -1542,9 +1542,6 @@
   <section class="plan-lane-section" aria-labelledby="planLaneTitle">
     <div class="plan-lane-dock" aria-label="Quick plan links">
       <h2 id="planLaneTitle" class="plan-lane-title">Start free, or choose the lane that fits</h2>
-      <p class="plan-lane-dock__intro">
-        Start free if you are still organizing, or choose the lane that matches the support you need.
-      </p>
       <div class="plan-lane-dock__grid">
         <a
           class="plan-lane-chip"

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -27,6 +27,7 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /data-portal-path="\/billing\/\?plan=embedded"/);
     assert.doesNotMatch(html, /Plans after the offer is clear/);
     assert.match(html, /Start free, or choose the lane that fits/);
+    assert.doesNotMatch(html, /Start free if you are still organizing, or choose the lane that matches the support you need\./);
     assert.doesNotMatch(html, /Pick the lane that fits\./);
     assert.match(html, /Get Organized/);
     assert.match(html, /Light Support/);


### PR DESCRIPTION
## Summary
- Removes the plan lane intro sentence from the homepage.
- Adds a customer journey regression assertion so the removed copy does not return silently.

## Validation
- `node --test tests/customer-journey.test.js tests/life-plan.test.js`