### PR TITLE
[codex] Combine homepage help sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -947,145 +947,6 @@
     .card h3 .plan-name { white-space: nowrap; }
     .card p { font-size: 1rem; }
 
-    #features {
-      position: relative;
-      overflow: hidden;
-      isolation: isolate;
-    }
-    #features::before,
-    #features::after {
-      content: "";
-      position: absolute;
-      inset: auto;
-      border-radius: 50%;
-      filter: blur(0.5px);
-      opacity: 0.7;
-      pointer-events: none;
-      transform: translateZ(0);
-      z-index: 0;
-    }
-    #features::before {
-      width: clamp(320px, 48vw, 520px);
-      height: clamp(320px, 48vw, 520px);
-      top: -180px;
-      right: -120px;
-      background: radial-gradient(circle, rgba(0, 255, 200, 0.45) 0%, rgba(0, 255, 200, 0) 70%);
-    }
-    #features::after {
-      width: clamp(280px, 42vw, 460px);
-      height: clamp(280px, 42vw, 460px);
-      bottom: -160px;
-      left: -140px;
-      background: radial-gradient(circle, rgba(255, 165, 92, 0.4) 0%, rgba(255, 165, 92, 0) 72%);
-    }
-    #features h2 { position: relative; z-index: 1; }
-    .features-grid {
-      position: relative;
-      z-index: 1;
-      display: grid;
-      grid-template-columns: repeat(3, minmax(0, 1fr));
-      gap: clamp(0.9rem, 1.5vw, 1.25rem);
-      width: min(980px, calc(100% - 2rem));
-    }
-    .feature-card {
-      width: 100%;
-      max-width: none;
-      min-width: 0;
-      padding: clamp(1.1rem, 1.5vw, 1.45rem);
-      align-items: flex-start;
-      text-align: left;
-      background: linear-gradient(150deg, rgba(255, 255, 255, 0.16), rgba(0, 0, 0, 0.15));
-      border: 1px solid rgba(255, 255, 255, 0.18);
-      box-shadow: 0 18px 36px rgba(8, 25, 35, 0.35);
-      backdrop-filter: blur(10px);
-      gap: 1.4rem;
-    }
-    .feature-card:hover {
-      background: linear-gradient(150deg, rgba(255, 255, 255, 0.26), rgba(0, 0, 0, 0.18));
-      transform: translateY(-8px);
-      box-shadow: 0 24px 48px rgba(8, 25, 35, 0.42);
-    }
-    .feature-card .feature-content {
-      display: flex;
-      flex-direction: column;
-      gap: 0.9rem;
-      align-items: flex-start;
-      width: 100%;
-    }
-    .feature-icon {
-      width: 56px;
-      height: 56px;
-      border-radius: 16px;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      background: rgba(0, 255, 200, 0.18);
-      color: var(--accent);
-      font-size: 1.6rem;
-      box-shadow: inset 0 0 0 1px rgba(0, 255, 200, 0.3), 0 12px 25px rgba(0, 0, 0, 0.35);
-      transition: transform 0.3s ease, box-shadow 0.3s ease;
-    }
-    .feature-card:hover .feature-icon {
-      transform: scale(1.08) translateY(-2px);
-      box-shadow: inset 0 0 0 1px rgba(0, 255, 200, 0.45), 0 18px 30px rgba(0, 0, 0, 0.4);
-    }
-    .feature-card h3 {
-      font-size: 1.35rem;
-      margin-bottom: 0.15rem;
-    }
-    .feature-card p {
-      color: rgba(255, 255, 255, 0.88);
-      margin-bottom: 0;
-    }
-    .feature-list {
-      display: flex;
-      flex-direction: column;
-      gap: 0.45rem;
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      width: 100%;
-    }
-    .feature-list li {
-      position: relative;
-      padding-left: 1.3rem;
-      font-size: 0.95rem;
-      color: rgba(255, 255, 255, 0.82);
-    }
-    .feature-list li::before {
-      content: "";
-      position: absolute;
-      left: 0;
-      top: 0.45rem;
-      width: 8px;
-      height: 8px;
-      border-radius: 50%;
-      background: var(--accent);
-      box-shadow: 0 0 12px rgba(0, 255, 200, 0.4);
-    }
-    .feature-cta {
-      margin-top: auto;
-      font-weight: 600;
-      color: var(--accent);
-      font-size: 0.95rem;
-      letter-spacing: 0.02em;
-    }
-    .feature-card:hover .feature-cta { color: #f9f9f9; }
-
-    @media (min-width: 1500px) {
-      .features-grid {
-        grid-template-columns: repeat(5, minmax(0, 1fr));
-        width: min(1400px, calc(100% - 2rem));
-      }
-    }
-    @media (max-width: 760px) {
-      .features-grid {
-        grid-template-columns: 1fr;
-      }
-      .feature-card .feature-content { gap: 0.8rem; }
-      .feature-card h3 { font-size: 1.25rem; }
-    }
-
     #testimonials {
       position: relative;
       overflow: hidden;
@@ -1385,6 +1246,28 @@
       font-size: 0.8rem;
       margin-top: 0.25rem;
     }
+    .vision-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.65rem;
+      margin-top: 1.2rem;
+    }
+    .vision-action {
+      color: var(--accent);
+      font-size: 0.95rem;
+      font-weight: 600;
+      text-decoration: none;
+      background: rgba(0,255,200,0.12);
+      border: 1px solid rgba(0,255,200,0.22);
+      border-radius: 999px;
+      padding: 0.55rem 0.9rem;
+      transition: background 0.3s ease, color 0.3s ease, transform 0.3s ease;
+    }
+    .vision-action:hover {
+      background: rgba(0,255,200,0.22);
+      color: #f9f9f9;
+      transform: translateY(-2px);
+    }
     .vision-footnote {
       max-width: 720px;
       margin: 0 auto;
@@ -1614,6 +1497,10 @@
             <li>Clear scope, design, copy, and setup so the project actually gets finished.</li>
             <li>Launch help that gets you from rough idea to live page.</li>
           </ul>
+          <div class="vision-actions" aria-label="Website and app help">
+            <a class="vision-action" href="websites.html">Website work</a>
+            <a class="vision-action" href="apps.html">App flows</a>
+          </div>
         </article>
         <article class="vision-card">
           <h3>Help you figure out the offer</h3>
@@ -1622,6 +1509,9 @@
             <li>Offer shaping, page structure, and messaging that make sense fast.</li>
             <li>Simple next steps instead of tech overload.</li>
           </ul>
+          <div class="vision-actions" aria-label="Strategy help">
+            <a class="vision-action" href="consulting.html">Book a session</a>
+          </div>
         </article>
         <article class="vision-card">
           <h3>Stay with you as it grows</h3>
@@ -1630,84 +1520,12 @@
             <li>Monthly help when you need changes, support, or a second brain.</li>
             <li>Practical systems for leads, content, and operations.</li>
           </ul>
+          <div class="vision-actions" aria-label="Ongoing help">
+            <a class="vision-action" href="support.html">Support desk</a>
+            <a class="vision-action" href="community.html">Builder community</a>
+          </div>
         </article>
       </div>
-    </div>
-  </section>
-
-  <section id="features" style="background: var(--bg-features);">
-    <h2>Practical help</h2>
-    <div class="card-grid features-grid">
-      <a href="websites.html" class="card feature-card">
-        <div class="feature-icon" aria-hidden="true">
-          <i class="fa-solid fa-globe"></i>
-        </div>
-        <div class="feature-content">
-          <h3>Websites &amp; Landing Pages</h3>
-          <p>Beautiful, responsive sites tailored to your brand and goals.</p>
-          <ul class="feature-list">
-            <li>Accessibility-first layouts, copy, and SEO foundations.</li>
-            <li>Launch guidance covering hosting, analytics, and security.</li>
-          </ul>
-          <span class="feature-cta">See website work →</span>
-        </div>
-      </a>
-      <a href="apps.html" class="card feature-card">
-        <div class="feature-icon" aria-hidden="true">
-          <i class="fa-solid fa-mobile-screen"></i>
-        </div>
-        <div class="feature-content">
-          <h3>App Designs</h3>
-          <p>Mobile-ready UI/UX design systems that engage and convert.</p>
-          <ul class="feature-list">
-            <li>Prototype flows, component libraries, and motion specs.</li>
-            <li>Hand-off ready files for dev teams or no-code builders.</li>
-          </ul>
-          <span class="feature-cta">Preview app flows →</span>
-        </div>
-      </a>
-      <a href="support.html" class="card feature-card">
-        <div class="feature-icon" aria-hidden="true">
-          <i class="fa-solid fa-headset"></i>
-        </div>
-        <div class="feature-content">
-          <h3>Unlimited Tech Support</h3>
-          <p>Ask anything—no limits. We're here to help you build.</p>
-          <ul class="feature-list">
-            <li>Async walkthroughs, screen recordings, and bug triage.</li>
-            <li>Automation, integrations, and systems advice on demand.</li>
-          </ul>
-          <span class="feature-cta">Meet the support desk →</span>
-        </div>
-      </a>
-      <a href="consulting.html" class="card feature-card">
-        <div class="feature-icon" aria-hidden="true">
-          <i class="fa-solid fa-lightbulb"></i>
-        </div>
-        <div class="feature-content">
-          <h3>Personal Consultations</h3>
-          <p>We'll meet with you to brainstorm, refine, and launch ideas.</p>
-          <ul class="feature-list">
-            <li>Strategy sessions to prioritize, scope, and plan next steps.</li>
-            <li>Documentation, templates, and resource recommendations.</li>
-          </ul>
-          <span class="feature-cta">Book a session →</span>
-        </div>
-      </a>
-      <a href="community.html" class="card feature-card">
-        <div class="feature-icon" aria-hidden="true">
-          <i class="fa-solid fa-people-group"></i>
-        </div>
-        <div class="feature-content">
-          <h3>Builder Community</h3>
-          <p>Join a community of creators, developers, and dreamers.</p>
-          <ul class="feature-list">
-            <li>Monthly build-alongs and office hours with the 3dvr.tech team.</li>
-            <li>Private channels to trade feedback, templates, and wins.</li>
-          </ul>
-          <span class="feature-cta">Join fellow builders →</span>
-        </div>
-      </a>
     </div>
   </section>
 

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -50,6 +50,13 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /Build your website or app/);
     assert.match(html, /Help you figure out the offer/);
     assert.match(html, /Stay with you as it grows/);
+    assert.match(html, /href="websites\.html">Website work<\/a>/);
+    assert.match(html, /href="apps\.html">App flows<\/a>/);
+    assert.match(html, /href="support\.html">Support desk<\/a>/);
+    assert.match(html, /href="consulting\.html">Book a session<\/a>/);
+    assert.match(html, /href="community\.html">Builder community<\/a>/);
+    assert.doesNotMatch(html, /<section id="features"/);
+    assert.doesNotMatch(html, /Practical help/);
     assert.doesNotMatch(html, /Calendar Hub/);
     assert.doesNotMatch(html, /Open the calendar →/);
     assert.doesNotMatch(html, /Self-Hosting Lab/);

--- a/tests/homepage-growth.test.js
+++ b/tests/homepage-growth.test.js
@@ -24,7 +24,8 @@ test('homepage ships Gun-backed experiment and focused CTA plumbing', async () =
   assert.match(html, /data-growth-cta="plan-free"/);
   assert.match(html, /data-growth-cta="plan-starter"/);
   assert.match(html, /grid-template-columns:\s*repeat\(3,\s*minmax\(0,\s*1fr\)\)/);
-  assert.match(html, /@media \(min-width:\s*1500px\)\s*{\s*\.features-grid\s*{\s*grid-template-columns:\s*repeat\(5,\s*minmax\(0,\s*1fr\)\)/);
+  assert.match(html, /class="vision-action" href="websites\.html">Website work<\/a>/);
+  assert.doesNotMatch(html, /class="card-grid features-grid"/);
   assert.match(html, /data-growth-cta="sticky-start-free"[^>]+data-portal-path="\/free-trial\.html"/);
   assert.match(html, /data-growth-cta="start-project-primary"[^>]+data-portal-path="\/start\/"/);
   assert.match(html, /data-growth-cta="plan-free"[^>]+data-portal-path="\/free-trial\.html"/);


### PR DESCRIPTION
## Summary
- Combines the repeated `What We Do` and `Practical help` homepage sections.
- Keeps the practical destination links inside the `What We Do` cards.
- Removes the unused practical-help card grid styles.

## Validation
- `node --test tests/customer-journey.test.js tests/homepage-growth.test.js`