### PR TITLE
[codex] Polish homepage token and team

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,12 +157,10 @@
       aspect-ratio: 1;
       border-radius: 50%;
       background:
-        radial-gradient(circle at 32% 24%, #45ffe3 0 10%, transparent 28%),
-        radial-gradient(circle at 48% 50%, #1768f2 0, #0f766e 54%, #07131f 100%);
+        radial-gradient(circle at 50% 48%, #1768f2 0, #0f766e 58%, #07131f 100%);
       border: 2px solid rgba(216, 255, 247, 0.9);
       box-shadow:
         inset -7px -8px 12px rgba(0, 0, 0, 0.3),
-        inset 5px 5px 12px rgba(255, 255, 255, 0.18),
         0 12px 28px rgba(0, 0, 0, 0.26);
       flex: 0 0 auto;
       overflow: hidden;
@@ -188,15 +186,7 @@
     }
 
     .site-token-mark::after {
-      inset: -14%;
-      background:
-        repeating-linear-gradient(
-          45deg,
-          rgba(255, 255, 255, 0.18) 0 3px,
-          transparent 3px 14px
-        );
-      opacity: 0.28;
-      mix-blend-mode: screen;
+      display: none;
     }
 
     .site-token-mark__text {
@@ -820,7 +810,7 @@
       margin: 0;
     }
     .hero-logo-card__tagline {
-      font-size: clamp(2rem, 5vw, 3.1rem);
+      font-size: clamp(2.6rem, 6.8vw, 4.35rem);
       font-weight: 900;
       line-height: 0.98;
       color: rgba(255,255,255,0.96);
@@ -1588,11 +1578,11 @@
         <p><strong>CEO / CTO / Founder</strong></p>
         <p>Visionary technologist creating the tools of tomorrow.</p>
       </div>
-      <div class="card team-card" data-link="https://bodhi-lowski.vercel.app/">
-        <img src="media/Bodhi_Lowski.jpg" alt="Bodhi Lowski" style="width: 100px; height: 100px; border-radius: 50%; object-fit: cover; margin-bottom: 1rem;">
-        <h3>Bodhi Lowski</h3>
-        <p><strong>Chief Marketing Officer</strong></p>
-        <p>Building the brand through grassroots storytelling and growth.</p>
+      <div class="card team-card" data-link="https://3dvr-mark-wells.vercel.app/">
+        <img src="media/mark-wells.png" alt="Mark Wells" style="width: 100px; height: 100px; border-radius: 50%; object-fit: cover; margin-bottom: 1rem;">
+        <h3>Mark Wells</h3>
+        <p><strong>Senior Developer</strong></p>
+        <p>10+ years in software design, specializing in real-time embedded systems and performance-critical code.</p>
       </div>
       <div class="card team-card" data-link="https://david-martinez.vercel.app/">
         <img src="media/David_Martinez.jpg" alt="David Martinez" style="width: 100px; height: 100px; border-radius: 50%; object-fit: cover; margin-bottom: 1rem;">
@@ -1611,12 +1601,6 @@
         <h3>Brandon Adolfo</h3>
         <p><strong>Junior Developer</strong></p>
         <p>Cross-platform mobile builder with an eye for design.</p>
-      </div>
-      <div class="card team-card" data-link="https://3dvr-mark-wells.vercel.app/">
-        <img src="media/mark-wells.png" alt="Mark Wells" style="width: 100px; height: 100px; border-radius: 50%; object-fit: cover; margin-bottom: 1rem;">
-        <h3>Mark Wells</h3>
-        <p><strong>Senior Developer</strong></p>
-        <p>10+ years in software design, specializing in real-time embedded systems and performance-critical code.</p>
       </div>
     </div>
   </section>

--- a/tests/logo-branding.test.js
+++ b/tests/logo-branding.test.js
@@ -15,7 +15,10 @@ describe('3dvr-web logo branding', () => {
     assert.match(html, /class="site-token-mark__main">3dvr<\/span>/);
     assert.match(html, /class="site-token-mark__suffix">\.tech<\/span>/);
     assert.match(html, /\.site-token-mark::before/);
-    assert.match(html, /radial-gradient\(circle at 48% 50%, #1768f2 0, #0f766e 54%, #07131f 100%\)/);
+    assert.match(html, /radial-gradient\(circle at 50% 48%, #1768f2 0, #0f766e 58%, #07131f 100%\)/);
+    assert.match(html, /\.site-token-mark::after\s+\{\s+display: none;/);
+    assert.doesNotMatch(html, /radial-gradient\(circle at 32% 24%, #45ffe3/);
+    assert.doesNotMatch(html, /repeating-linear-gradient\(\s+45deg,\s+rgba\(255, 255, 255, 0\.18\)/);
     assert.match(html, /<span class="site-brand__name">3dvr<span>\.tech<\/span><\/span>/);
     assert.match(html, /<strong>3dvr<span>\.tech<\/span><\/strong>/);
     assert.match(html, /data-3dvr-token/);


### PR DESCRIPTION
## What changed

- Made the homepage "Build the future" tagline larger.
- Removed the bright glare/shine treatment from the small header coin.
- Removed Bodhi Lowski from the Meet the Team section.
- Moved Mark Wells up next to Thomas in the team order.
- Updated the logo branding test so the flatter coin treatment is covered.

## Impact

This is a homepage presentation update only. No billing or portal link behavior changed.

## Validation

- `npm run test:unit`