### PR TITLE
[codex] Simplify team section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1575,32 +1575,26 @@
       <div class="card team-card" data-link="https://tmsteph.com">
         <img src="media/Thomas_Stephens.jpg" alt="Thomas Stephens" style="width: 100px; height: 100px; border-radius: 50%; object-fit: cover; margin-bottom: 1rem;">
         <h3>Thomas Stephens</h3>
-        <p><strong>CEO / CTO / Founder</strong></p>
+        <p><strong>Founder</strong></p>
         <p>Visionary technologist creating the tools of tomorrow.</p>
       </div>
       <div class="card team-card" data-link="https://3dvr-mark-wells.vercel.app/">
         <img src="media/mark-wells.png" alt="Mark Wells" style="width: 100px; height: 100px; border-radius: 50%; object-fit: cover; margin-bottom: 1rem;">
         <h3>Mark Wells</h3>
-        <p><strong>Senior Developer</strong></p>
+        <p><strong>Developer</strong></p>
         <p>10+ years in software design, specializing in real-time embedded systems and performance-critical code.</p>
-      </div>
-      <div class="card team-card" data-link="https://david-martinez.vercel.app/">
-        <img src="media/David_Martinez.jpg" alt="David Martinez" style="width: 100px; height: 100px; border-radius: 50%; object-fit: cover; margin-bottom: 1rem;">
-        <h3>David Martinez</h3>
-        <p><strong>Lead Developer</strong></p>
-        <p>Crafting immersive 3D and web experiences.</p>
       </div>
       <div class="card team-card" data-link="https://thirdeyeprintco.com/">
         <img src="media/Esai_Gamboa.jpg" alt="Esai Gamboa" style="width: 100px; height: 100px; border-radius: 50%; object-fit: cover; margin-bottom: 1rem;">
         <h3>Esai Gamboa</h3>
-        <p><strong>Financial Specialist</strong></p>
-        <p>Linux Expert and Chief Financial Officer.</p>
+        <p><strong>Sales and Financial Expert</strong></p>
+        <p>Linux expert helping shape practical sales, finance, and operations decisions.</p>
       </div>
-      <div class="card team-card" data-link="https://brandon-adolfo.vercel.app/">
-        <img src="media/Brandon_Adolfo.jpg" alt="Brandon Adolfo" style="width: 100px; height: 100px; border-radius: 50%; object-fit: cover; margin-bottom: 1rem;">
-        <h3>Brandon Adolfo</h3>
-        <p><strong>Junior Developer</strong></p>
-        <p>Cross-platform mobile builder with an eye for design.</p>
+      <div class="card team-card" data-link="https://david-martinez.vercel.app/">
+        <img src="media/David_Martinez.jpg" alt="David Martinez" style="width: 100px; height: 100px; border-radius: 50%; object-fit: cover; margin-bottom: 1rem;">
+        <h3>David Martinez</h3>
+        <p><strong>Developer</strong></p>
+        <p>Crafting immersive 3D and web experiences.</p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## What changed

- Changed Thomas Stephens' role to "Founder".
- Kept the team order to Thomas, Mark, Esai, then David.
- Updated Mark and David to simpler "Developer" labels.
- Updated Esai to "Sales and Financial Expert" with less corporate copy.
- Removed Brandon from the Meet the Team list so the section contains only the requested four people.

## Impact

Homepage team copy/order only. No billing, portal, or routing behavior changed.

## Validation

- `npm run test:unit`