### PR TITLE
[codex] Update public footer

### DIFF
--- a/apps.html
+++ b/apps.html
@@ -199,8 +199,7 @@
   </section>
 
   <footer>
-    <p>&copy; 2025 <a href="https://3dvr.tech" target="_blank">3dvr.tech</a> — Open Source. Open Future.</p>
-    <p><a href="friends.html">Friends &amp; Family</a></p>
+    <p>&copy; 2026 <a href="https://3dvr.tech" target="_blank">3dvr.tech</a> — Open Source. Open Future.</p>
   </footer>
 
   <script>

--- a/community.html
+++ b/community.html
@@ -199,8 +199,7 @@
   </section>
 
   <footer>
-    <p>&copy; 2025 <a href="https://3dvr.tech" target="_blank">3dvr.tech</a> — Open Source. Open Future.</p>
-    <p><a href="friends.html">Friends &amp; Family</a></p>
+    <p>&copy; 2026 <a href="https://3dvr.tech" target="_blank">3dvr.tech</a> — Open Source. Open Future.</p>
   </footer>
 
   <script>

--- a/consulting.html
+++ b/consulting.html
@@ -199,8 +199,7 @@
   </section>
 
   <footer>
-    <p>&copy; 2025 <a href="https://3dvr.tech" target="_blank">3dvr.tech</a> — Open Source. Open Future.</p>
-    <p><a href="friends.html">Friends &amp; Family</a></p>
+    <p>&copy; 2026 <a href="https://3dvr.tech" target="_blank">3dvr.tech</a> — Open Source. Open Future.</p>
   </footer>
 
   <script>

--- a/friends.html
+++ b/friends.html
@@ -363,8 +363,7 @@
   </section>
 
   <footer>
-    <p>&copy; 2025 <a href="https://3dvr.tech" target="_blank">3dvr.tech</a> — Open Source. Open Future.</p>
-    <p><a href="friends.html">Friends &amp; Family</a></p>
+    <p>&copy; 2026 <a href="https://3dvr.tech" target="_blank">3dvr.tech</a> — Open Source. Open Future.</p>
   </footer>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -1656,8 +1656,7 @@
 
 
   <footer style="background: #111; color: #aaa; text-align: center; padding: 2rem 1rem; font-size: 0.95rem;">
-    <p style="margin-top: 0;">&copy; 2025 <a href="https://3dvr.tech" target="_blank" style="color: var(--accent);">3dvr.tech</a> — Open Source. Open Future.</p>
-    <p><a href="friends.html" style="color: var(--accent); text-decoration: none;">Friends &amp; Family</a></p>
+    <p style="margin-top: 0;">&copy; 2026 <a href="https://3dvr.tech" target="_blank" style="color: var(--accent);">3dvr.tech</a> — Open Source. Open Future.</p>
     <p><a href="https://github.com/tmsteph/3dvr-web" target="_blank" style="color: var(--accent); text-decoration: none;">✏️ Edit this page on GitHub</a></p>
   </footer>
 

--- a/support.html
+++ b/support.html
@@ -200,8 +200,7 @@
   </section>
 
   <footer>
-    <p>&copy; 2025 <a href="https://3dvr.tech" target="_blank">3dvr.tech</a> — Open Source. Open Future.</p>
-    <p><a href="friends.html">Friends &amp; Family</a></p>
+    <p>&copy; 2026 <a href="https://3dvr.tech" target="_blank">3dvr.tech</a> — Open Source. Open Future.</p>
   </footer>
 
   <script>

--- a/websites.html
+++ b/websites.html
@@ -199,8 +199,7 @@
   </section>
 
   <footer>
-    <p>&copy; 2025 <a href="https://3dvr.tech" target="_blank">3dvr.tech</a> — Open Source. Open Future.</p>
-    <p><a href="friends.html">Friends &amp; Family</a></p>
+    <p>&copy; 2026 <a href="https://3dvr.tech" target="_blank">3dvr.tech</a> — Open Source. Open Future.</p>
   </footer>
 
   <script>


### PR DESCRIPTION
## What changed

- Updated public footer copyright years from 2025 to 2026.
- Removed the Friends & Family footer link from the public static pages that had it.

## Impact

Footer presentation only. No billing, portal, or routing behavior changed.

## Validation

- `npm run test:unit`