### PR TITLE
[codex] Add about link to homepage nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -1348,7 +1348,7 @@
       <a href="subscribe/index.html">Start Free</a>
       <a href="subscribe/index.html">Plans</a>
       <a href="#vision">What We Do</a>
-      <a href="system.html">System</a>
+      <a href="#about">About</a>
       <a href="#testimonials">Trust</a>
       <a href="https://portal.3dvr.tech">Portal</a>
     </nav>

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -47,6 +47,8 @@ describe('3dvr-web customer journey copy', () => {
         navHtml.indexOf('>Plans<') < navHtml.indexOf('>What We Do<'),
       'Plans nav link should sit between Start Free and What We Do',
     );
+    assert.match(navHtml, /href="#about">About<\/a>/);
+    assert.doesNotMatch(navHtml, /href="system\.html">System<\/a>/);
     assert.match(html, /Build your website or app/);
     assert.match(html, /Help you figure out the offer/);
     assert.match(html, /Stay with you as it grows/);


### PR DESCRIPTION
## Summary
- Replace the top homepage `System` nav item with an `About` link.
- Point the new nav item at the existing `#about` section.
- Add unit coverage so the homepage nav keeps the About link and does not restore the System link.

## Validation
- `npm run test:unit`