### PR TITLE
[codex] Move about nav before portal

### DIFF
--- a/index.html
+++ b/index.html
@@ -1348,8 +1348,8 @@
       <a href="subscribe/index.html">Start Free</a>
       <a href="subscribe/index.html">Plans</a>
       <a href="#vision">What We Do</a>
-      <a href="#about">About</a>
       <a href="#testimonials">Trust</a>
+      <a href="#about">About</a>
       <a href="https://portal.3dvr.tech">Portal</a>
     </nav>
   </header>

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -48,6 +48,11 @@ describe('3dvr-web customer journey copy', () => {
       'Plans nav link should sit between Start Free and What We Do',
     );
     assert.match(navHtml, /href="#about">About<\/a>/);
+    assert.ok(
+      navHtml.indexOf('>Trust<') < navHtml.indexOf('>About<') &&
+        navHtml.indexOf('>About<') < navHtml.indexOf('>Portal<'),
+      'About nav link should sit between Trust and Portal',
+    );
     assert.doesNotMatch(navHtml, /href="system\.html">System<\/a>/);
     assert.match(html, /Build your website or app/);
     assert.match(html, /Help you figure out the offer/);


### PR DESCRIPTION
## Summary
- Move the homepage `About` nav item after `Trust`.
- Keep `About` immediately before the external `Portal` link.
- Add unit coverage for the requested nav order.

## Validation
- `npm run test:unit`