### PR TITLE
[codex] Expand trust section spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -938,9 +938,15 @@
     .card p { font-size: 1rem; }
 
     #testimonials {
+      min-height: calc(100vh - 82px);
+      padding: clamp(6rem, 9vw, 8rem) 2rem;
       position: relative;
       overflow: hidden;
       isolation: isolate;
+    }
+    #testimonials > h2 {
+      position: relative;
+      z-index: 1;
     }
     #testimonials::before,
     #testimonials::after {
@@ -992,6 +998,12 @@
     }
     .testimonial-card:hover::after {
       opacity: 1;
+    }
+    @media (max-width: 760px) {
+      #testimonials {
+        min-height: auto;
+        padding-block: 4.5rem;
+      }
     }
 
     #partners {

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -99,6 +99,7 @@ describe('3dvr-web customer journey copy', () => {
     assert.doesNotMatch(html, /A real place to land when you need a site, support, or a launch plan\./);
     assert.doesNotMatch(html, /Best for real businesses that need a site, follow-up, updates, and calmer operations\./);
     assert.match(html, /Trusted by friends, family, and small businesses/);
+    assert.match(html, /#testimonials\s*\{[\s\S]*?min-height:\s*calc\(100vh - 82px\);[\s\S]*?padding:\s*clamp\(6rem, 9vw, 8rem\) 2rem;/);
     assert.match(html, /See plans/);
     assert.match(html, /hero-logo-card/);
     assert.ok(heroIndex !== -1, 'Hero section should exist');


### PR DESCRIPTION
## Summary
- Give the homepage Trust section a laptop/full-screen treatment with viewport-height sizing and larger vertical padding.
- Keep mobile shorter with an auto-height override.
- Add unit coverage for the Trust section spacing rule.

## Validation
- `npm run test:unit`
- Local Playwright check at 1366x768 for `#testimonials`; section height measured 789px against a 768px viewport and all testimonial cards fit inside the viewport.