### PR TITLE
[codex] Remove about section graphic

### DIFF
--- a/index.html
+++ b/index.html
@@ -1315,12 +1315,10 @@
       margin: 0;
     }
     .about-shell {
-      width: min(1040px, 100%);
+      width: min(920px, 100%);
       min-height: min(720px, calc(100vh - 180px));
       display: grid;
-      grid-template-columns: minmax(0, 1fr) minmax(320px, 0.82fr);
       align-items: center;
-      gap: clamp(2.25rem, 5vw, 5rem);
       margin: 0 auto;
     }
     .about-copy {
@@ -1393,71 +1391,6 @@
       color: #fff;
       border-color: #fff;
     }
-    .about-visual {
-      position: relative;
-      display: grid;
-      gap: 1rem;
-      padding: clamp(1rem, 3vw, 1.5rem);
-      border: 1px solid rgba(255, 255, 255, 0.16);
-      border-radius: 8px;
-      background:
-        linear-gradient(180deg, rgba(255, 255, 255, 0.11), rgba(255, 255, 255, 0.04)),
-        repeating-linear-gradient(90deg, rgba(255,255,255,0.05) 0 1px, transparent 1px 42px);
-      box-shadow: 0 30px 70px rgba(0, 0, 0, 0.28);
-    }
-    .about-visual::before {
-      content: "";
-      position: absolute;
-      inset: 1rem;
-      border: 1px solid rgba(0, 255, 200, 0.18);
-      border-radius: 6px;
-      pointer-events: none;
-    }
-    .about-node {
-      position: relative;
-      z-index: 1;
-      display: grid;
-      grid-template-columns: auto 1fr;
-      gap: 0.85rem;
-      align-items: center;
-      padding: 1rem;
-      border-radius: 8px;
-      border: 1px solid rgba(255, 255, 255, 0.16);
-      background: rgba(7, 19, 31, 0.58);
-    }
-    .about-node:nth-child(2) {
-      margin-left: clamp(0.8rem, 4vw, 2.4rem);
-    }
-    .about-node:nth-child(3) {
-      margin-left: clamp(1.6rem, 7vw, 4.2rem);
-    }
-    .about-node:nth-child(4) {
-      margin-left: clamp(0.4rem, 3vw, 1.4rem);
-    }
-    .about-node__icon {
-      display: grid;
-      place-items: center;
-      width: 3rem;
-      height: 3rem;
-      border-radius: 8px;
-      background: rgba(0, 255, 200, 0.12);
-      color: var(--accent);
-      font-weight: 900;
-      border: 1px solid rgba(0, 255, 200, 0.3);
-    }
-    .about-node strong {
-      display: block;
-      color: #fff;
-      font-size: 1rem;
-      margin-bottom: 0.15rem;
-    }
-    .about-node span {
-      display: block;
-      color: rgba(255, 255, 255, 0.7);
-      font-size: 0.9rem;
-      line-height: 1.45;
-    }
-
     @media (max-width: 860px) {
       .about-section {
         min-height: auto;
@@ -1465,13 +1398,6 @@
       }
       .about-shell {
         min-height: auto;
-        grid-template-columns: 1fr;
-      }
-      .about-node,
-      .about-node:nth-child(2),
-      .about-node:nth-child(3),
-      .about-node:nth-child(4) {
-        margin-left: 0;
       }
     }
 
@@ -1819,36 +1745,6 @@
           </article>
         </div>
         <a class="about-github" href="https://github.com/tmsteph/3dvr-web" target="_blank" rel="noopener">Contribute on GitHub</a>
-      </div>
-      <div class="about-visual" aria-label="3dvr.tech ecosystem layers">
-        <div class="about-node">
-          <span class="about-node__icon" aria-hidden="true">HW</span>
-          <div>
-            <strong>Hardware</strong>
-            <span>Repairable devices and field-ready setups.</span>
-          </div>
-        </div>
-        <div class="about-node">
-          <span class="about-node__icon" aria-hidden="true">SW</span>
-          <div>
-            <strong>Software</strong>
-            <span>Web apps, portals, and simple systems.</span>
-          </div>
-        </div>
-        <div class="about-node">
-          <span class="about-node__icon" aria-hidden="true">SP</span>
-          <div>
-            <strong>Support</strong>
-            <span>Direct help to keep the work moving.</span>
-          </div>
-        </div>
-        <div class="about-node">
-          <span class="about-node__icon" aria-hidden="true">OS</span>
-          <div>
-            <strong>Open source</strong>
-            <span>Shared pieces that can improve in public.</span>
-          </div>
-        </div>
       </div>
     </div>
   </section>

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -129,10 +129,8 @@ describe('3dvr-web customer journey copy', () => {
     assert.match(html, /class="about-shell"/);
     assert.match(html, /We believe everyone deserves the tools to build their digital life/);
     assert.match(html, /Contribute on GitHub/);
-    assert.match(html, /<strong>Hardware<\/strong>/);
-    assert.match(html, /<strong>Software<\/strong>/);
-    assert.match(html, /<strong>Support<\/strong>/);
-    assert.match(html, /<strong>Open source<\/strong>/);
+    assert.doesNotMatch(html, /class="about-visual"/);
+    assert.doesNotMatch(html, /class="about-node"/);
     assert.doesNotMatch(html, /Contributions welcome on <a/);
     assert.doesNotMatch(html, /Message me/i);
     assert.doesNotMatch(html, /mailto:3dvr\.tech@gmail\.com\?subject=3DVR%20Project%20Inquiry/);


### PR DESCRIPTION
## Summary
- Remove the right-side ecosystem graphic from the homepage About section.
- Keep the expanded About layout and widen the remaining content for a cleaner single-column presentation.
- Update unit coverage to assert the graphic markup stays removed.

## Validation
- `npm run test:unit`