### PR TITLE
Make public site free-first

### DIFF
--- a/friends.html
+++ b/friends.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta
     name="description"
-    content="Try 3DVR free, get one clear next step, or join the Friends & Family Pass for $5/month."
+    content="Try 3DVR free. Sort one messy thought, pick one small next step, and support the Friends & Family Pass only if it helps."
   />
   <meta name="robots" content="index, follow" />
   <link rel="canonical" href="https://3dvr.tech/friends.html" />
@@ -19,7 +19,7 @@
   <meta property="og:title" content="Friends, Family &amp; Coworkers | 3DVR.Tech" />
   <meta
     property="og:description"
-    content="Try 3DVR free, get one clear next step, or join the Friends & Family Pass for $5/month."
+    content="Try 3DVR free. Sort one messy thought, pick one small next step, and support the Friends & Family Pass only if it helps."
   />
   <meta property="og:url" content="https://3dvr.tech/friends.html" />
   <meta property="og:image" content="https://3dvr.tech/3DVR.png" />
@@ -28,7 +28,7 @@
   <meta name="twitter:title" content="Friends, Family &amp; Coworkers | 3DVR.Tech" />
   <meta
     name="twitter:description"
-    content="Try 3DVR free, get one clear next step, or join the Friends & Family Pass for $5/month."
+    content="Try 3DVR free. Sort one messy thought, pick one small next step, and support the Friends & Family Pass only if it helps."
   />
   <meta name="twitter:image" content="https://3dvr.tech/3DVR.png" />
   <script type="application/ld+json">
@@ -306,15 +306,14 @@
 
   <section class="hero">
     <div class="section-inner">
-      <h1>Try 3DVR free. If it helps, join for $5.</h1>
+      <h1>Try 3DVR free.</h1>
       <p>
-        This is the simple friends, family, and coworker invite. Use 3DVR to sort
-        a messy thought, pick one next step, and see if the portal helps.
+        Sort one messy thought. Pick one small next step. No card.
       </p>
       <div class="button-row">
         <a class="btn" href="https://portal.3dvr.tech/friends-family/">Open the invite</a>
-        <a class="btn" href="https://portal.3dvr.tech/free-trial.html">Start free</a>
-        <a class="btn" href="https://portal.3dvr.tech/sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dstarter">Join for $5/month</a>
+        <a class="btn" href="https://portal.3dvr.tech/life/index.html">Start free</a>
+        <a class="btn" href="https://portal.3dvr.tech/sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dstarter">Support for $5/month</a>
       </div>
       <div class="anchor-links">
         Jump to:
@@ -330,7 +329,7 @@
       <h2>What you get</h2>
       <ul class="mini-list">
         <li>Free: one small place to check in and choose your next step.</li>
-        <li>$5/month: early access, light support, and a real way to help 3DVR grow.</li>
+        <li>$5/month: optional support and a light monthly path as the tools grow.</li>
         <li>No pressure: cancel anytime. Try it before you pay.</li>
       </ul>
     </div>
@@ -341,16 +340,16 @@
       <h2>Plans</h2>
       <div class="card-grid">
         <article class="card" id="free">
-          <h3>Get Clear</h3>
+          <h3>Free Plan</h3>
           <div class="price-tag">Free</div>
-          <p>Use the portal to sort life, ideas, money, or work into one small next step.</p>
-          <a class="btn" href="https://portal.3dvr.tech/free-trial.html">Start Free</a>
+          <p>Use the portal to check in, sort what matters, and pick one small move for today.</p>
+          <a class="btn" href="https://portal.3dvr.tech/life/index.html">Start Daily Direction</a>
         </article>
         <article class="card" id="supporter">
           <h3>Friends &amp; Family Pass</h3>
           <div class="price-tag">$5/month</div>
-          <p>Help fund the work and get the first look at new tools, experiments, and support paths.</p>
-          <a class="btn" href="https://portal.3dvr.tech/sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dstarter">Join for $5/month</a>
+          <p>Support 3DVR and get a light monthly support path as the tools grow.</p>
+          <a class="btn" href="https://portal.3dvr.tech/sign-in.html?redirect=%2Fbilling%2F%3Fplan%3Dstarter">Support for $5/month</a>
         </article>
         <article class="card" id="builder">
           <h3>Build With Me</h3>
@@ -367,9 +366,9 @@
       <h2>Text this to one person</h2>
       <div class="share-box">
         <p>
-          I am trying a simple 3DVR invite: use it free to sort one messy thought
-          and pick a next step. If it helps, there is a $5/month friends and
-          family pass too. Try it here: https://portal.3dvr.tech/friends-family/
+          I am testing a simple 3DVR flow. It is free and only takes a minute:
+          sort one messy thought and pick one next step. You do not need a business
+          or website. Try it here: https://portal.3dvr.tech/friends-family/
         </p>
       </div>
       <p class="note-line">Short, honest, and not awkward. Send it to someone who might actually use it.</p>
@@ -400,7 +399,7 @@
         </div>
         <div class="faq-item">
           <h4>What kind of help is included?</h4>
-          <p>Free helps you get clear. $5 is early access and light support. $20 is more direct project help.</p>
+          <p>Free helps you pick one small step. $5 supports the project. $20 is more direct project help.</p>
         </div>
         <div class="faq-item">
           <h4>Is this a contract?</h4>

--- a/growth/homepage-experiment.js
+++ b/growth/homepage-experiment.js
@@ -23,15 +23,15 @@
   const VARIANTS = Object.freeze({
     clarity: Object.freeze({
       key: 'clarity',
-      eyebrow: 'Websites. Apps. Direct support.',
-      primary: 'We help small businesses actually launch.',
-      body: 'Launch a site, offer, or simple business system with direct support from idea to live.',
+      eyebrow: 'Free Plan',
+      primary: 'Start where you are.',
+      body: 'Use 3DVR free to sort one messy thought and pick one small next step. If you already have a project, site, offer, or business system to launch, get direct help.',
     }),
     traction: Object.freeze({
       key: 'traction',
-      eyebrow: 'Launch fast. Start selling.',
-      primary: 'Get your project live.',
-      body: '3dvr helps small businesses and creators launch without getting stuck in tech.',
+      eyebrow: 'Launch help',
+      primary: 'Already have something to launch?',
+      body: 'Get direct help with a page, offer, workflow, or simple system after the free first step is clear.',
     }),
   });
 

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <meta name="color-scheme" content="dark light" />
   <meta
     name="description"
-    content="3dvr.tech helps small businesses and creators launch websites, offers, and simple systems with direct support."
+    content="Start free with 3dvr.tech to sort one messy thought and pick one small next step, or get direct help launching a site, offer, or simple system."
   />
   <meta name="keywords" content="3dvr, 3dvr tech, 3dvr websites, community web design, open web lab" />
   <meta name="robots" content="index, follow" />
@@ -21,19 +21,19 @@
 
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="3dvr.tech" />
-  <meta property="og:title" content="3dvr.tech | Launch your website, offer, or project" />
+  <meta property="og:title" content="3dvr.tech | Start where you are" />
   <meta
     property="og:description"
-    content="Get your website, offer, or simple business system live with direct help from 3dvr.tech."
+    content="Use 3DVR free to sort one messy thought and pick one small next step. Get direct help when you are ready to launch."
   />
   <meta property="og:url" content="https://3dvr.tech/" />
   <meta property="og:image" content="https://3dvr.tech/3DVR.png" />
   <meta property="og:image:alt" content="3dvr.tech logomark" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="3dvr.tech | Launch your website, offer, or project" />
+  <meta name="twitter:title" content="3dvr.tech | Start where you are" />
   <meta
     name="twitter:description"
-    content="Get your website, offer, or simple business system live with direct help from 3dvr.tech."
+    content="Use 3DVR free to sort one messy thought and pick one small next step. Get direct help when you are ready to launch."
   />
   <meta name="twitter:image" content="https://3dvr.tech/3DVR.png" />
   <script defer src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
@@ -64,7 +64,7 @@
       "name": "3dvr.tech",
       "url": "https://3dvr.tech/",
       "logo": "https://3dvr.tech/3DVR.png",
-      "description": "3dvr.tech helps small businesses and creators launch websites, offers, and simple systems with direct support.",
+      "description": "3dvr.tech helps people sort one messy thought, pick one small next step, and get direct launch help when they are ready.",
       "sameAs": [
         "https://www.facebook.com/3dvr.facebook/",
         "https://www.linkedin.com/company/3dvrtech",
@@ -1459,7 +1459,7 @@
     </div>
 
     <nav id="mainNav">
-      <a href="subscribe/index.html">Start Free</a>
+      <a href="https://portal.3dvr.tech/life/index.html">Start Free</a>
       <a href="subscribe/index.html">Plans</a>
       <a href="#vision">What We Do</a>
       <a href="#testimonials">Trust</a>
@@ -1471,14 +1471,14 @@
   <a
     class="sticky-cta"
     data-growth-cta="sticky-start-free"
-    data-portal-path="/free-trial.html"
-    href="https://portal.3dvr.tech/free-trial.html"
+    data-portal-path="/life/index.html"
+    href="https://portal.3dvr.tech/life/index.html"
   >Start Free</a>
 
   <section class="hero">
     <div class="hero-inner">
       <div class="hero-intro">
-        <p id="heroEyebrow" class="hero-eyebrow">Websites. Apps. Direct support.</p>
+        <p id="heroEyebrow" class="hero-eyebrow">Free Plan</p>
       </div>
       <div class="hero-visual">
         <div class="hero-logo-card hero-logo-card--token">
@@ -1504,22 +1504,27 @@
       </div>
       <div class="hero-content">
         <h1 class="hero-headline">
-          <span id="heroHeadlinePrimary" class="hero-headline-primary">We help small businesses actually launch.</span>
+          <span id="heroHeadlinePrimary" class="hero-headline-primary">Start where you are.</span>
         </h1>
         <p id="heroBody">
-          Launch a site, offer, or simple business system with direct support from idea to live.
+          Use 3DVR free to sort one messy thought and pick one small next step. If you already have a project, site, offer, or business system to launch, get direct help.
         </p>
         <div class="hero-buttons">
           <a
             class="hero-button hero-button--primary"
-            data-growth-cta="start-project-primary"
-            data-portal-path="/start/"
-            href="https://portal.3dvr.tech/start/"
+            data-growth-cta="start-free-primary"
+            data-portal-path="/life/index.html"
+            href="https://portal.3dvr.tech/life/index.html"
           >
-            Start a project
+            Start free
           </a>
-          <a class="hero-button hero-button--ghost" data-growth-cta="see-plans" href="subscribe/index.html">
-            See plans
+          <a
+            class="hero-button hero-button--ghost"
+            data-growth-cta="direct-help-primary"
+            data-portal-path="/start/#paid-lanes"
+            href="https://portal.3dvr.tech/start/#paid-lanes"
+          >
+            I need help launching something
           </a>
         </div>
       </div>
@@ -1528,16 +1533,16 @@
 
   <section class="plan-lane-section" aria-labelledby="planLaneTitle">
     <div class="plan-lane-dock" aria-label="Quick plan links">
-      <h2 id="planLaneTitle" class="plan-lane-title">Start free, or choose the lane that fits</h2>
+      <h2 id="planLaneTitle" class="plan-lane-title">Free first, paid help when you need it</h2>
       <div class="plan-lane-dock__grid">
         <a
           class="plan-lane-chip"
           data-growth-cta="plan-free"
-          data-portal-path="/free-trial.html"
-          href="https://portal.3dvr.tech/free-trial.html"
+          data-portal-path="/life/index.html"
+          href="https://portal.3dvr.tech/life/index.html"
         >
-          <strong>Free</strong>
-          <span>Get Organized</span>
+          <strong>Free Plan</strong>
+          <span>One small step</span>
         </a>
         <a
           class="plan-lane-chip"

--- a/tests/auto-business.test.js
+++ b/tests/auto-business.test.js
@@ -58,12 +58,13 @@ describe('3DVR auto-business design document', () => {
     const sitemap = await readFile(new URL('../sitemap.xml', import.meta.url), 'utf8');
 
     assert.match(homeHtml, /href="subscribe\/index\.html">Plans<\/a>/);
-    assert.match(homeHtml, /href="subscribe\/index\.html">\s*See plans\s*<\/a>/);
+    assert.match(homeHtml, /data-growth-cta="direct-help-primary"[\s\S]*?data-portal-path="\/start\/#paid-lanes"/);
+    assert.match(homeHtml, /I need help launching something/);
     assert.doesNotMatch(homeHtml, /Internal offer notes/);
     assert.doesNotMatch(homeHtml, /auto-business design document/);
     assert.doesNotMatch(homeHtml, /href="auto-business\/"/);
     assert.doesNotMatch(homeHtml, /href="auto-business\/">Plans<\/a>/);
-    assert.doesNotMatch(homeHtml, /href="auto-business\/">\s*See plans\s*<\/a>/);
+    assert.doesNotMatch(homeHtml, /href="auto-business\/">\s*I need help launching something\s*<\/a>/);
     assert.doesNotMatch(homeHtml, /Open plans and project sprints/);
     assert.doesNotMatch(sitemap, /<loc>https:\/\/3dvr\.tech\/plans\/<\/loc>/);
     assert.doesNotMatch(sitemap, /<loc>https:\/\/3dvr\.tech\/auto-business\/<\/loc>/);

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -11,25 +11,27 @@ describe('3dvr-web customer journey copy', () => {
     const whatWeDoIndex = html.indexOf('<section id="vision"');
     const navHtml = html.match(/<nav id="mainNav">[\s\S]*?<\/nav>/)?.[0] || '';
 
-    assert.match(html, /Websites\. Apps\. Direct support\./);
-    assert.match(html, /We help small businesses actually launch\./);
-    assert.match(html, /Launch a site, offer, or simple business system with direct support from idea to live\./);
+    assert.match(html, /Free Plan/);
+    assert.match(html, /Start where you are\./);
+    assert.match(html, /Use 3DVR free to sort one messy thought and pick one small next step\./);
+    assert.match(html, /If you already have a project, site, offer, or business system to launch, get direct help\./);
     assert.match(html, /Start Free/);
-    assert.match(html, /Start a project/);
+    assert.match(html, /Start free/);
+    assert.match(html, /I need help launching something/);
     assert.match(html, /Launch now!/);
     assert.match(html, /Build the future/);
     assert.doesNotMatch(html, /Build the future\./);
-    assert.match(html, /data-portal-path="\/start\/"/);
-    assert.match(html, /data-portal-path="\/free-trial\.html"/);
+    assert.match(html, /data-portal-path="\/life\/index\.html"/);
+    assert.match(html, /data-portal-path="\/start\/#paid-lanes"/);
     assert.match(html, /data-portal-path="\/billing\/\?plan=starter"/);
     assert.match(html, /data-portal-path="\/billing\/\?plan=pro"/);
     assert.match(html, /data-portal-path="\/billing\/\?plan=builder"/);
     assert.match(html, /data-portal-path="\/billing\/\?plan=embedded"/);
     assert.doesNotMatch(html, /Plans after the offer is clear/);
-    assert.match(html, /Start free, or choose the lane that fits/);
+    assert.match(html, /Free first, paid help when you need it/);
     assert.doesNotMatch(html, /Start free if you are still organizing, or choose the lane that matches the support you need\./);
     assert.doesNotMatch(html, /Pick the lane that fits\./);
-    assert.match(html, /Get Organized/);
+    assert.match(html, /One small step/);
     assert.match(html, /Light Support/);
     assert.match(html, /Launch now!/);
     assert.match(html, /Default for businesses/);
@@ -100,7 +102,7 @@ describe('3dvr-web customer journey copy', () => {
     assert.doesNotMatch(html, /Best for real businesses that need a site, follow-up, updates, and calmer operations\./);
     assert.match(html, /Trusted by friends, family, and small businesses/);
     assert.match(html, /#testimonials\s*\{[\s\S]*?min-height:\s*calc\(100vh - 82px\);[\s\S]*?padding:\s*clamp\(6rem, 9vw, 8rem\) 2rem;/);
-    assert.match(html, /See plans/);
+    assert.match(html, /I need help launching something/);
     assert.match(html, /hero-logo-card/);
     assert.ok(heroIndex !== -1, 'Hero section should exist');
     assert.ok(planLaneIndex !== -1, 'Plan lane section should exist');
@@ -220,14 +222,14 @@ describe('3dvr-web customer journey copy', () => {
   it('makes the friends and family page sendable with real portal links', async () => {
     const html = await readFile(new URL('../friends.html', import.meta.url), 'utf8');
 
-    assert.match(html, /Try 3DVR free\. If it helps, join for \$5\./);
-    assert.match(html, /This is the simple friends, family, and coworker invite\./);
+    assert.match(html, /Try 3DVR free\./);
+    assert.match(html, /Sort one messy thought\. Pick one small next step\. No card\./);
     assert.match(html, /Free: one small place to check in and choose your next step\./);
     assert.match(html, /Friends &amp; Family Pass/);
-    assert.match(html, /Join for \$5\/month/);
+    assert.match(html, /Support for \$5\/month/);
     assert.match(html, /Text this to one person/);
     assert.match(html, /https:\/\/portal\.3dvr\.tech\/friends-family\//);
-    assert.match(html, /https:\/\/portal\.3dvr\.tech\/free-trial\.html/);
+    assert.match(html, /https:\/\/portal\.3dvr\.tech\/life\/index\.html/);
     assert.match(html, /https:\/\/portal\.3dvr\.tech\/sign-in\.html\?redirect=%2Fbilling%2F%3Fplan%3Dstarter/);
     assert.match(html, /https:\/\/portal\.3dvr\.tech\/sign-in\.html\?redirect=%2Fbilling%2F%3Fplan%3Dpro/);
     assert.doesNotMatch(html, /REPLACE_ME_/);

--- a/tests/homepage-growth.test.js
+++ b/tests/homepage-growth.test.js
@@ -15,8 +15,8 @@ test('homepage ships Gun-backed experiment and focused CTA plumbing', async () =
   assert.doesNotMatch(html, /id="heroFeedbackStatus"/);
   assert.doesNotMatch(html, /data-growth-feedback=/);
   assert.match(html, /data-growth-cta="sticky-start-free"/);
-  assert.match(html, /data-growth-cta="start-project-primary"/);
-  assert.match(html, /data-growth-cta="see-plans"/);
+  assert.match(html, /data-growth-cta="start-free-primary"/);
+  assert.match(html, /data-growth-cta="direct-help-primary"/);
   assert.match(html, /class="hero-logo-card(?:\s|")/);
   assert.match(html, /Build the future/);
   assert.doesNotMatch(html, /Build the future\./);
@@ -27,9 +27,10 @@ test('homepage ships Gun-backed experiment and focused CTA plumbing', async () =
   assert.match(html, /grid-template-columns:\s*repeat\(3,\s*minmax\(0,\s*1fr\)\)/);
   assert.match(html, /class="vision-action" href="websites\.html">Website work<\/a>/);
   assert.doesNotMatch(html, /class="card-grid features-grid"/);
-  assert.match(html, /data-growth-cta="sticky-start-free"[^>]+data-portal-path="\/free-trial\.html"/);
-  assert.match(html, /data-growth-cta="start-project-primary"[^>]+data-portal-path="\/start\/"/);
-  assert.match(html, /data-growth-cta="plan-free"[^>]+data-portal-path="\/free-trial\.html"/);
+  assert.match(html, /data-growth-cta="sticky-start-free"[^>]+data-portal-path="\/life\/index\.html"/);
+  assert.match(html, /data-growth-cta="start-free-primary"[^>]+data-portal-path="\/life\/index\.html"/);
+  assert.match(html, /data-growth-cta="direct-help-primary"[^>]+data-portal-path="\/start\/#paid-lanes"/);
+  assert.match(html, /data-growth-cta="plan-free"[^>]+data-portal-path="\/life\/index\.html"/);
   assert.match(html, /data-growth-cta="plan-starter"[^>]+data-portal-path="\/billing\/\?plan=starter"/);
   assert.match(html, /data-growth-cta="plan-20"[^>]+data-portal-path="\/billing\/\?plan=pro"/);
   assert.match(html, /data-growth-cta="plan-50"[^>]+data-portal-path="\/billing\/\?plan=builder"/);
@@ -56,8 +57,9 @@ test('homepage ships Gun-backed experiment and focused CTA plumbing', async () =
 
   assert.match(js, /EXPERIMENT_CONFIG_PATH = \['3dvr-portal', 'growth', 'experiments', 'homepage-hero', 'config'\]/);
   assert.match(js, /EXPERIMENT_EVENT_PATH = \['3dvr-portal', 'growth', 'experiments', 'homepage-hero', 'events'\]/);
-  assert.match(js, /eyebrow: 'Launch fast\. Start selling\.'/);
-  assert.match(js, /primary: 'Get your project live\.'/);
+  assert.match(js, /eyebrow: 'Free Plan'/);
+  assert.match(js, /primary: 'Start where you are\.'/);
+  assert.match(js, /primary: 'Already have something to launch\?'/);
   assert.match(js, /function chooseVariant/);
   assert.match(js, /function applyVariant/);
   assert.match(js, /function logView/);

--- a/tests/life-plan.test.js
+++ b/tests/life-plan.test.js
@@ -7,7 +7,7 @@ test('free plan copy points to the portal start path in plain language', async (
   const plansHtml = await readFile(new URL('../subscribe/index.html', import.meta.url), 'utf8');
   const freeHtml = await readFile(new URL('../subscribe/free-plan.html', import.meta.url), 'utf8');
 
-  assert.match(homeHtml, /Start free, or choose the lane that fits/);
+  assert.match(homeHtml, /Free first, paid help when you need it/);
   assert.match(homeHtml, /Light Support/);
   assert.match(plansHtml, /Get organized, sort out your next steps, and start using the portal without paying first\./);
   assert.match(plansHtml, /Daily check-ins and weekly reflection/);


### PR DESCRIPTION
## Summary
- Change the 3dvr.tech homepage hero to lead with the Free Plan and Daily Direction
- Keep direct launch help as the second path instead of the first assumption
- Align the public friends page with the no-card one-small-step invite
- Update homepage growth variants so experiments stay free-first

## Tests
- node --test tests/customer-journey.test.js tests/homepage-growth.test.js tests/life-plan.test.js tests/auto-business.test.js