### PR TITLE
Remove subscribe page intro copy

### DIFF
--- a/subscribe/index.html
+++ b/subscribe/index.html
@@ -172,16 +172,6 @@
   </header>
 
   <main>
-    <section class="hero">
-      <h1>Choose Your 3dvr.tech Plan</h1>
-      <p>Launch in 3 Days is the fast entry point. Builder at $50/month is the default business lane when you already have leads, customers, quotes, follow-up, or weekly operations to keep moving.</p>
-      <p class="hero-helper">
-        New here? Start with a plan below. Returning? <a data-portal-path="/billing/" href="https://portal.3dvr.tech/billing/" target="_blank" rel="noopener">Open the billing center</a>.
-      </p>
-      <p class="hero-helper">Start free to get organized, then move into the portal when you're ready.</p>
-      <p class="hero-helper">Use the same portal account for free access, upgrades, invoices, and support.</p>
-    </section>
-
     <section id="plans" class="grid">
       <!-- FREE -->
       <article id="free" class="card">

--- a/tests/customer-journey.test.js
+++ b/tests/customer-journey.test.js
@@ -172,7 +172,8 @@ describe('3dvr-web customer journey copy', () => {
 
   it('makes the main plans page explicit about continuing in the portal', async () => {
     const html = await readFile(new URL('../subscribe/index.html', import.meta.url), 'utf8');
-    assert.match(html, /Launch in 3 Days is the fast entry point\. Builder at \$50\/month is the default business lane/);
+    assert.doesNotMatch(html, /Launch in 3 Days is the fast entry point\. Builder at \$50\/month is the default business lane/);
+    assert.doesNotMatch(html, /Use the same portal account for free access, upgrades, invoices, and support/);
     assert.match(html, /Default for active businesses/);
     assert.match(html, /Get organized, sort out your next steps, and start using the portal without paying first\./);
     assert.match(html, /Choose by business type/);

--- a/tests/life-plan.test.js
+++ b/tests/life-plan.test.js
@@ -11,7 +11,7 @@ test('free plan copy points to the portal start path in plain language', async (
   assert.match(homeHtml, /Light Support/);
   assert.match(plansHtml, /Get organized, sort out your next steps, and start using the portal without paying first\./);
   assert.match(plansHtml, /Daily check-ins and weekly reflection/);
-  assert.match(plansHtml, /Start free to get organized/);
+  assert.doesNotMatch(plansHtml, /Start free to get organized/);
   assert.match(freeHtml, /Get organized, sort out your next steps, and start inside the portal\./);
   assert.match(freeHtml, /The free plan gives you a simple place to check in daily, reflect each week, and build momentum before you pay for anything\./);
   assert.match(freeHtml, /data-portal-path="\/start\/"/);


### PR DESCRIPTION
## Summary
- Remove the introductory subscribe-page hero copy so the plans page starts directly with the plan cards.
- Update copy regression tests to keep that removed intro from returning.

## Verification
- npm run test:unit