### PR TITLE
Add services lab A/B tracking loop

### DIFF
--- a/growth/services-experiment.js
+++ b/growth/services-experiment.js
@@ -1,0 +1,235 @@
+'use strict';
+
+(function initServicesExperiment(window, document) {
+  if (!window || !document) {
+    return;
+  }
+
+  const VISITOR_ID_KEY = '3dvr-growth.visitor-id';
+  const SERVICES_VARIANT_KEY = '3dvr-growth.services-lab.variant';
+  const SERVICES_VIEW_DAY_KEY = '3dvr-growth.services-lab.view-day';
+  const EVENT_PATH = ['3dvr-portal', 'growth', 'experiments', 'services-lab', 'events'];
+  const GUN_PEERS = window.__GUN_PEERS__ || [
+    'wss://relay.3dvr.tech/gun',
+    'wss://gun-relay-3dvr.fly.dev/gun',
+  ];
+  const SOURCE = 'services-lab';
+
+  const VARIANTS = Object.freeze({
+    local: Object.freeze({
+      key: 'local',
+      eyebrow: 'For local service businesses',
+      headline: 'Turn local attention into booked jobs.',
+      body: '3dvr.tech builds practical websites for repair shops, wellness providers, local crews, and solo operators who need calls, quote requests, and trust faster.',
+    }),
+    launch: Object.freeze({
+      key: 'launch',
+      eyebrow: 'For creators and new offers',
+      headline: 'Launch the offer before momentum fades.',
+      body: 'Bring the idea, rough notes, or half-built page. 3dvr.tech helps shape the message, publish the site, and connect the next step so people can act.',
+    }),
+    systems: Object.freeze({
+      key: 'systems',
+      eyebrow: 'For messy business tech',
+      headline: 'Stop losing leads in the handoff.',
+      body: 'Clean up the simple but expensive gaps around your website: forms, booking, payments, subscriptions, follow-up, and the tech stack holding it together.',
+    }),
+  });
+
+  const refs = {
+    eyebrow: document.getElementById('serviceEyebrow'),
+    headline: document.getElementById('serviceHeadline'),
+    body: document.getElementById('serviceBody'),
+    billingLinks: Array.from(document.querySelectorAll('[data-service-billing-link]')),
+    trackedLinks: Array.from(document.querySelectorAll('[data-service-cta]')),
+  };
+
+  const state = {
+    visitorId: '',
+    variantKey: 'local',
+  };
+
+  function safeStorageGet(key) {
+    try {
+      return window.localStorage.getItem(key) || '';
+    } catch (_error) {
+      return '';
+    }
+  }
+
+  function safeStorageSet(key, value) {
+    try {
+      window.localStorage.setItem(key, value);
+    } catch (_error) {
+      // Storage may be unavailable in private browsing. Continue in memory.
+    }
+  }
+
+  function todayKey() {
+    return new Date().toISOString().slice(0, 10);
+  }
+
+  function createId() {
+    if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+      return window.crypto.randomUUID();
+    }
+    return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  }
+
+  function getVisitorId() {
+    const existing = safeStorageGet(VISITOR_ID_KEY);
+    if (existing) {
+      return existing;
+    }
+    const next = createId();
+    safeStorageSet(VISITOR_ID_KEY, next);
+    return next;
+  }
+
+  function hashString(value) {
+    let hash = 0;
+    for (let index = 0; index < value.length; index += 1) {
+      hash = ((hash << 5) - hash) + value.charCodeAt(index);
+      hash |= 0;
+    }
+    return Math.abs(hash);
+  }
+
+  function normalizeVariant(value = '') {
+    const normalized = String(value || '').trim().toLowerCase();
+    return VARIANTS[normalized] ? normalized : '';
+  }
+
+  function variantFromUrl() {
+    const params = new URLSearchParams(window.location.search);
+    return normalizeVariant(params.get('variant'));
+  }
+
+  function chooseVariant(visitorId) {
+    const explicit = variantFromUrl();
+    if (explicit) {
+      safeStorageSet(SERVICES_VARIANT_KEY, explicit);
+      return explicit;
+    }
+
+    const stored = normalizeVariant(safeStorageGet(SERVICES_VARIANT_KEY));
+    if (stored) {
+      return stored;
+    }
+
+    const keys = Object.keys(VARIANTS);
+    const chosen = keys[hashString(visitorId) % keys.length] || 'local';
+    safeStorageSet(SERVICES_VARIANT_KEY, chosen);
+    return chosen;
+  }
+
+  function applyVariant(variantKey) {
+    const variant = VARIANTS[variantKey] || VARIANTS.local;
+    state.variantKey = variant.key;
+    document.documentElement.dataset.servicesVariant = variant.key;
+
+    if (refs.eyebrow) refs.eyebrow.textContent = variant.eyebrow;
+    if (refs.headline) refs.headline.textContent = variant.headline;
+    if (refs.body) refs.body.textContent = variant.body;
+  }
+
+  function addTrackingParams(url, cta) {
+    const nextUrl = new URL(url, window.location.href);
+    nextUrl.searchParams.set('source', SOURCE);
+    nextUrl.searchParams.set('variant', state.variantKey);
+    nextUrl.searchParams.set('cta', cta || 'unknown');
+    nextUrl.searchParams.set('visitor', state.visitorId);
+    return nextUrl.toString();
+  }
+
+  function decorateBillingLinks() {
+    refs.billingLinks.forEach(link => {
+      const cta = String(link.dataset.serviceCta || '').trim();
+      link.href = addTrackingParams(link.href, cta);
+    });
+  }
+
+  function getGun() {
+    if (typeof window.Gun !== 'function') {
+      return null;
+    }
+    try {
+      return window.Gun({ peers: GUN_PEERS });
+    } catch (error) {
+      console.warn('Services experiment Gun init failed', error);
+      return null;
+    }
+  }
+
+  function getNode(root, path) {
+    return path.reduce((node, key) => (node && typeof node.get === 'function' ? node.get(key) : null), root);
+  }
+
+  function writeEvent(root, payload) {
+    const node = getNode(root, EVENT_PATH);
+    if (!node || typeof node.get !== 'function') {
+      return;
+    }
+    const id = String(payload.id || createId());
+    node.get(id).put({
+      ...payload,
+      id,
+    });
+  }
+
+  function logView(root) {
+    const key = `${todayKey()}:${state.variantKey}`;
+    if (safeStorageGet(SERVICES_VIEW_DAY_KEY) === key) {
+      return;
+    }
+    safeStorageSet(SERVICES_VIEW_DAY_KEY, key);
+    writeEvent(root, {
+      visitorId: state.visitorId,
+      page: SOURCE,
+      eventType: 'view',
+      variant: state.variantKey,
+      timestamp: new Date().toISOString(),
+      source: '3dvr-web',
+    });
+  }
+
+  function logCtaClick(root, cta) {
+    writeEvent(root, {
+      visitorId: state.visitorId,
+      page: SOURCE,
+      eventType: 'cta-click',
+      cta,
+      variant: state.variantKey,
+      timestamp: new Date().toISOString(),
+      source: '3dvr-web',
+    });
+  }
+
+  function bindInteractions(root) {
+    refs.trackedLinks.forEach(link => {
+      link.addEventListener('click', () => {
+        logCtaClick(root, String(link.dataset.serviceCta || 'unknown').trim());
+      });
+    });
+  }
+
+  function init() {
+    const gun = getGun();
+    state.visitorId = getVisitorId();
+    applyVariant(chooseVariant(state.visitorId));
+    decorateBillingLinks();
+    logView(gun);
+    bindInteractions(gun);
+  }
+
+  window.__3DVR_SERVICES_EXPERIMENT__ = {
+    variants: VARIANTS,
+    eventPath: EVENT_PATH,
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
+})(window, document);

--- a/services-lab.html
+++ b/services-lab.html
@@ -119,8 +119,7 @@
 
     .brand img {
       width: 46px;
-      height: auto;
-      max-height: 46px;
+      height: 46px;
       flex: 0 0 auto;
       object-fit: contain;
     }
@@ -538,12 +537,14 @@
     }
   </style>
   <script defer src="/_vercel/insights/script.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/gun/gun.js"></script>
+  <script defer src="growth/services-experiment.js"></script>
 </head>
 <body>
   <header class="site-header">
     <div class="page-shell">
       <a class="brand" href="index.html" aria-label="3dvr.tech home">
-        <img src="3DVR.png" alt="3dvr.tech logo" />
+        <img src="assets/logo-3dvr.svg" alt="3dvr.tech logo" />
         <span>
           3dvr.tech
           <small>Services lab</small>
@@ -552,7 +553,7 @@
       <nav class="nav-actions" aria-label="Page navigation">
         <a class="nav-link" href="index.html">Home</a>
         <a class="nav-link" href="#offers">Offers</a>
-        <a class="button" href="mailto:3dvr.tech@gmail.com?subject=Project%20fit%20call%20with%203dvr.tech" target="_blank" rel="noopener">
+        <a class="button" data-service-cta="header-email" href="mailto:3dvr.tech@gmail.com?subject=Project%20fit%20call%20with%203dvr.tech" target="_blank" rel="noopener">
           <i class="fa-solid fa-paper-plane" aria-hidden="true"></i>
           Start a project
         </a>
@@ -563,18 +564,22 @@
   <main>
     <section class="page-shell hero" aria-labelledby="hero-title">
       <div class="hero-copy">
-        <div class="eyebrow">Websites, offers, and simple systems</div>
-        <h1 id="hero-title">Get online without getting lost.</h1>
-        <p>
+        <div class="eyebrow" id="serviceEyebrow">Websites, offers, and simple systems</div>
+        <h1 id="hero-title"><span id="serviceHeadline">Get online without getting lost.</span></h1>
+        <p id="serviceBody">
           3dvr.tech helps small businesses, creators, and local teams turn scattered ideas into a clean website,
           a clear offer, and the lightweight tech stack needed to keep moving.
         </p>
         <div class="hero-actions">
-          <a class="button" href="mailto:3dvr.tech@gmail.com?subject=I%20want%20help%20launching%20a%20website" target="_blank" rel="noopener">
+          <a class="button" data-service-billing-link data-service-cta="hero-billing" href="https://portal.3dvr.tech/billing/?plan=custom&source=services-lab&variant=baseline&cta=hero-billing" target="_blank" rel="noopener">
+            <i class="fa-solid fa-credit-card" aria-hidden="true"></i>
+            Open billing path
+          </a>
+          <a class="button secondary" data-service-cta="hero-email" href="mailto:3dvr.tech@gmail.com?subject=I%20want%20help%20launching%20a%20website" target="_blank" rel="noopener">
             <i class="fa-solid fa-calendar-check" aria-hidden="true"></i>
             Book a fit call
           </a>
-          <a class="button secondary" href="#offers">
+          <a class="button secondary" data-service-cta="hero-offers" href="#offers">
             <i class="fa-solid fa-layer-group" aria-hidden="true"></i>
             See the paths
           </a>
@@ -722,9 +727,9 @@
             3dvr.tech can help turn it into a page people can actually act on.
           </p>
         </div>
-        <a class="button" href="mailto:3dvr.tech@gmail.com?subject=Project%20fit%20call%20with%203dvr.tech" target="_blank" rel="noopener">
-          <i class="fa-solid fa-paper-plane" aria-hidden="true"></i>
-          Email 3dvr.tech
+        <a class="button" data-service-billing-link data-service-cta="footer-billing" href="https://portal.3dvr.tech/billing/?plan=custom&source=services-lab&variant=baseline&cta=footer-billing" target="_blank" rel="noopener">
+          <i class="fa-solid fa-credit-card" aria-hidden="true"></i>
+          Open project billing
         </a>
       </div>
     </section>

--- a/tests/services-experiment.test.js
+++ b/tests/services-experiment.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+test('services lab page ships tracked audience variants and billing CTAs', async () => {
+  const html = await readFile(new URL('../services-lab.html', import.meta.url), 'utf8');
+  const js = await readFile(new URL('../growth/services-experiment.js', import.meta.url), 'utf8');
+
+  assert.match(html, /id="serviceEyebrow"/);
+  assert.match(html, /id="serviceHeadline"/);
+  assert.match(html, /id="serviceBody"/);
+  assert.match(html, /data-service-cta="hero-billing"/);
+  assert.match(html, /data-service-cta="footer-billing"/);
+  assert.match(html, /data-service-billing-link/);
+  assert.match(html, /href="https:\/\/portal\.3dvr\.tech\/billing\/\?plan=custom&source=services-lab&variant=baseline&cta=hero-billing"/);
+  assert.match(html, /src="https:\/\/cdn\.jsdelivr\.net\/npm\/gun\/gun\.js"/);
+  assert.match(html, /src="growth\/services-experiment\.js"/);
+
+  assert.match(js, /EVENT_PATH = \['3dvr-portal', 'growth', 'experiments', 'services-lab', 'events'\]/);
+  assert.match(js, /local: Object\.freeze/);
+  assert.match(js, /headline: 'Turn local attention into booked jobs\.'/);
+  assert.match(js, /launch: Object\.freeze/);
+  assert.match(js, /systems: Object\.freeze/);
+  assert.match(js, /function variantFromUrl/);
+  assert.match(js, /function decorateBillingLinks/);
+  assert.match(js, /nextUrl\.searchParams\.set\('source', SOURCE\)/);
+  assert.match(js, /nextUrl\.searchParams\.set\('variant', state\.variantKey\)/);
+  assert.match(js, /nextUrl\.searchParams\.set\('cta', cta \|\| 'unknown'\)/);
+  assert.match(js, /function logCtaClick/);
+});


### PR DESCRIPTION
## Summary
- Add a services-lab experiment controller with local, launch, and systems audience variants
- Track service-page views and CTA clicks to the existing Gun-backed growth namespace
- Route billing CTAs to portal billing with source, variant, cta, and visitor params
- Swap the header logo to the square SVG mark so it does not appear squeezed

## Environment impact
- Static page remains noindex/nofollow and unlinked from the homepage
- Adds a new static JS file at /growth/services-experiment.js
- No Stripe, billing API, or portal behavior changed; links use existing /billing/?plan=custom path

## Verification
- npm run test:unit
- Playwright screenshots for /services-lab.html?variant=local, launch, systems