### PR TITLE
Remove SD Vanlife testimonial

### DIFF
--- a/index.html
+++ b/index.html
@@ -999,6 +999,9 @@
     .testimonial-card:hover::after {
       opacity: 1;
     }
+    .testimonial-card:not([data-link]) {
+      cursor: default;
+    }
     @media (max-width: 760px) {
       #testimonials {
         min-height: auto;
@@ -1619,7 +1622,7 @@
       <div class="card testimonial-card" data-link="https://www.brendadyestephens.com/"><h3>SC Librarian</h3><p>“3dvr.tech helped me create a modern and accessible site for my library project. Tech support has been amazing.”</p></div>
       <div class="card testimonial-card" data-link="https://cruisersgarage.com/"><h3>Cruisers Garage</h3><p>“They built a slick, mobile-friendly landing page for our custom motorcycles in no time. Highly recommend.”</p></div>
       <div class="card testimonial-card" data-link="https://www.gif.edu.gt/"><h3>GIF English</h3><p>“We needed a site that could handle English lessons, scheduling, and videos. 3dvr.tech delivered exactly what we imagined.”</p></div>
-      <div class="card testimonial-card" data-link="https://www.sdvanlife.com/"><h3>SD Vanlife</h3><p>“Thomas and 3dvr.tech gave us the tools and guidance we needed to launch our van conversion business online.”</p></div>
+      <div class="card testimonial-card"><h3>SD Vanlife</h3><p>“Thomas and 3dvr.tech gave us the tools and guidance we needed to launch our van conversion business online.”</p></div>
     </div>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -999,9 +999,6 @@
     .testimonial-card:hover::after {
       opacity: 1;
     }
-    .testimonial-card:not([data-link]) {
-      cursor: default;
-    }
     @media (max-width: 760px) {
       #testimonials {
         min-height: auto;
@@ -1622,7 +1619,6 @@
       <div class="card testimonial-card" data-link="https://www.brendadyestephens.com/"><h3>SC Librarian</h3><p>“3dvr.tech helped me create a modern and accessible site for my library project. Tech support has been amazing.”</p></div>
       <div class="card testimonial-card" data-link="https://cruisersgarage.com/"><h3>Cruisers Garage</h3><p>“They built a slick, mobile-friendly landing page for our custom motorcycles in no time. Highly recommend.”</p></div>
       <div class="card testimonial-card" data-link="https://www.gif.edu.gt/"><h3>GIF English</h3><p>“We needed a site that could handle English lessons, scheduling, and videos. 3dvr.tech delivered exactly what we imagined.”</p></div>
-      <div class="card testimonial-card"><h3>SD Vanlife</h3><p>“Thomas and 3dvr.tech gave us the tools and guidance we needed to launch our van conversion business online.”</p></div>
     </div>
   </section>
 


### PR DESCRIPTION
## What changed

- Removed the SD Vanlife testimonial card and its broken outbound URL from the homepage.

## Verification

- Confirmed the destination returns HTTP 404 for GET and HEAD requests.
- Confirmed no SD Vanlife content or `sdvanlife.com` URL remains in the repository.
- `npm run test:unit` — 36 tests passed.
- `git diff --check` passed.

## Environment impact

- Homepage-only change; no billing or portal-origin behavior is affected.
