### PR TITLE
Point agent installs at portal monorepo

### DIFF
--- a/install-agent
+++ b/install-agent
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-INSTALLER_URL="${THREEDVR_INSTALLER_URL:-https://raw.githubusercontent.com/tmsteph/3dvr-agent/main/install.sh}"
+INSTALLER_URL="${THREEDVR_INSTALLER_URL:-https://raw.githubusercontent.com/tmsteph/3dvr-portal/main/apps/agent/install.sh}"
 
 if command -v curl >/dev/null 2>&1; then
   curl -fsSL "$INSTALLER_URL" | bash
 elif command -v wget >/dev/null 2>&1; then
   wget -qO- "$INSTALLER_URL" | bash
 else
-  printf '%s\n' "3dvr-agent installer needs curl or wget."
+  printf '%s\n' "The 3dvr agent installer needs curl or wget."
   printf '%s\n' "Install one of them, then run:"
   printf '%s\n' "  curl -Ls https://3dvr.tech/install-agent | bash"
   exit 1

--- a/install-agent.html
+++ b/install-agent.html
@@ -202,14 +202,14 @@
 
     <section class="card" aria-labelledby="manual-install">
       <h2 id="manual-install">Manual fallback</h2>
-      <pre><code>git clone https://github.com/tmsteph/3dvr-agent.git
-cd 3dvr-agent
+      <pre><code>git clone https://github.com/tmsteph/3dvr-portal.git
+cd 3dvr-portal/apps/agent
 ./install.sh
 3dvr setup
 3dvr doctor</code></pre>
       <p class="note">
-        The installer stores the checkout under <code>~/.3dvr/agent</code> by default.
-        Override with <code>THREEDVR_HOME</code>, <code>THREEDVR_AGENT_DIR</code>, or <code>THREEDVR_BIN_DIR</code>.
+        The installer stores the portal monorepo under <code>~/.3dvr/portal</code> and runs the agent from <code>apps/agent</code>.
+        Override with <code>THREEDVR_HOME</code>, <code>THREEDVR_REPO_DIR</code>, <code>THREEDVR_AGENT_DIR</code>, or <code>THREEDVR_BIN_DIR</code>.
       </p>
     </section>
   </main>

--- a/tests/agent-install.test.js
+++ b/tests/agent-install.test.js
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+test('agent install entry points use the portal monorepo', async () => {
+  const [script, page] = await Promise.all([
+    readFile(new URL('../install-agent', import.meta.url), 'utf8'),
+    readFile(new URL('../install-agent.html', import.meta.url), 'utf8'),
+  ]);
+
+  assert.match(script, /tmsteph\/3dvr-portal\/main\/apps\/agent\/install\.sh/);
+  assert.doesNotMatch(script, /tmsteph\/3dvr-agent/);
+  assert.match(page, /git clone https:\/\/github\.com\/tmsteph\/3dvr-portal\.git/);
+  assert.match(page, /cd 3dvr-portal\/apps\/agent/);
+  assert.match(page, /~\/\.3dvr\/portal/);
+  assert.doesNotMatch(page, /github\.com\/tmsteph\/3dvr-agent/);
+});


### PR DESCRIPTION
## Outcome

Keeps the public agent installer and manual setup page accurate after the agent moves into `3dvr-portal/apps/agent`.

## Changes

- `https://3dvr.tech/install-agent` fetches the installer from `tmsteph/3dvr-portal/main/apps/agent/install.sh`
- manual cloning instructions use `3dvr-portal/apps/agent`
- install-path copy documents `~/.3dvr/portal` and the separate agent subdirectory
- adds a regression test that rejects references to the old standalone source

Paired portal PR: tmsteph/3dvr-portal#1159

## Verification

- unit suite: 37/37 passed
- shell syntax check passed
- no billing, Stripe, portal-origin, or Vercel routing changes
