### PR TITLE
refine homepage coin as a thinner ridged 3dvr mark

### DIFF
--- a/homepage-logo-token.js
+++ b/homepage-logo-token.js
@@ -39,7 +39,6 @@
     idleSpin: 0,
     spinVelocityX: 0,
     spinVelocityY: 0,
-    portalPhase: 0,
     lastTimestamp: 0,
     lastDragTimestamp: 0,
     renderer: null,
@@ -112,28 +111,6 @@
       context.stroke();
     }
     context.globalAlpha = 1;
-    context.restore();
-
-    context.save();
-    context.translate(size / 2, size / 2);
-    const portalGradient = context.createRadialGradient(0, 0, size * 0.035, 0, 0, size * 0.34);
-    portalGradient.addColorStop(0, '#020814');
-    portalGradient.addColorStop(0.38, '#0a2742');
-    portalGradient.addColorStop(0.78, '#135a74');
-    portalGradient.addColorStop(1, 'rgba(19, 90, 116, 0)');
-    context.globalAlpha = 0.92;
-    context.fillStyle = portalGradient;
-    context.beginPath();
-    context.arc(0, 0, size * 0.35, 0, Math.PI * 2);
-    context.fill();
-    context.globalAlpha = 0.72;
-    context.strokeStyle = '#69f5ff';
-    context.lineWidth = 6;
-    for (let portalRing = 1; portalRing <= 3; portalRing += 1) {
-      context.beginPath();
-      context.arc(0, 0, size * (0.1 + portalRing * 0.075), 0, Math.PI * 2);
-      context.stroke();
-    }
     context.restore();
 
     context.beginPath();
@@ -241,22 +218,6 @@
     ridges.rotation.x = Math.PI / 2;
     group.add(ridges);
 
-    const portalRings = new THREE.Group();
-    const portalMaterials = [0x76f7ff, 0x36b8ff, 0x9e7bff].map((color) => new THREE.MeshBasicMaterial({
-      color,
-      transparent: true,
-      opacity: 0.72
-    }));
-    [0.34, 0.54, 0.74].forEach((radius, index) => {
-      const ring = new THREE.Mesh(new THREE.TorusGeometry(radius, 0.012, 10, 96), portalMaterials[index]);
-      ring.position.z = 0.142;
-      ring.userData.phase = index * 1.8;
-      ring.userData.radius = radius;
-      portalRings.add(ring);
-    });
-    group.add(portalRings);
-    group.userData.portalRings = portalRings;
-
     return group;
   }
 
@@ -274,8 +235,6 @@
     }
 
     state.idleSpin += elapsed * (IDLE_QUARTER_SPIN_SPEED + state.spinVelocityY);
-    state.portalPhase = (state.portalPhase + elapsed * 0.0024) % (Math.PI * 2);
-
     if (state.spinVelocityY !== 0) {
       state.spinVelocityY *= Math.pow(SPIN_MOMENTUM_DECAY, elapsed / 16.67);
       if (Math.abs(state.spinVelocityY) < MIN_SPIN_MOMENTUM) {
@@ -327,15 +286,6 @@
     if (state.token && state.renderer && state.scene && state.camera) {
       const rotation = getRenderRotation();
       state.token.rotation.set(rotation.x, rotation.y, rotation.z);
-      const portalRings = state.token.userData.portalRings;
-      if (portalRings) {
-        portalRings.rotation.z = state.portalPhase * 0.42;
-        portalRings.children.forEach((ring) => {
-          const pulse = 1 + Math.sin(state.portalPhase * 2 + ring.userData.phase) * 0.035;
-          ring.scale.setScalar(pulse);
-          ring.rotation.z = state.portalPhase * (ring.userData.radius < 0.5 ? -0.7 : 0.5);
-        });
-      }
       state.renderer.render(state.scene, state.camera);
       return;
     }
@@ -507,29 +457,6 @@
       context.moveTo(innerX, innerY);
       context.lineTo(outerX, outerY);
       context.strokeStyle = ridge % 2 ? '#ffe9a3' : '#8f5b16';
-      context.stroke();
-    }
-    context.restore();
-
-    context.save();
-    context.globalAlpha = 0.82;
-    const portalRadius = radius * 0.72;
-    const portalGradient = context.createRadialGradient(0, 0, portalRadius * 0.06, 0, 0, portalRadius);
-    portalGradient.addColorStop(0, '#020814');
-    portalGradient.addColorStop(0.46, '#0a2742');
-    portalGradient.addColorStop(0.82, '#135a74');
-    portalGradient.addColorStop(1, 'rgba(19, 90, 116, 0)');
-    context.fillStyle = portalGradient;
-    context.beginPath();
-    context.arc(0, 0, portalRadius, 0, Math.PI * 2);
-    context.fill();
-    context.globalAlpha = 0.74;
-    context.lineWidth = Math.max(1, size * 0.006);
-    context.strokeStyle = '#69f5ff';
-    for (let portalRing = 1; portalRing <= 3; portalRing += 1) {
-      const ringRadius = portalRadius * (0.28 + portalRing * 0.2 + Math.sin(state.portalPhase * 2 + portalRing) * 0.012);
-      context.beginPath();
-      context.arc(0, 0, ringRadius, state.portalPhase * (portalRing % 2 ? 0.45 : -0.35), Math.PI * 2 + state.portalPhase * (portalRing % 2 ? 0.45 : -0.35));
       context.stroke();
     }
     context.restore();

--- a/homepage-logo-token.js
+++ b/homepage-logo-token.js
@@ -136,9 +136,6 @@
     context.shadowBlur = 24;
     context.font = '900 168px Poppins, Inter, Arial, sans-serif';
     context.fillText('3dvr', 0, -20);
-    context.fillStyle = '#8a5515';
-    context.font = '800 96px Poppins, Inter, Arial, sans-serif';
-    context.fillText('.tech', 0, 122);
     context.restore();
 
     const texture = new THREE.CanvasTexture(textureCanvas);
@@ -186,7 +183,7 @@
     });
 
     const body = new THREE.Mesh(
-      new THREE.CylinderGeometry(1.45, 1.45, 0.34, 128, 1, false),
+      new THREE.CylinderGeometry(1.45, 1.45, 0.24, 128, 1, false),
       [sideMaterial, frontMaterial, backMaterial]
     );
     body.rotation.x = Math.PI / 2;
@@ -197,13 +194,29 @@
       metalness: 0.86,
       roughness: 0.18
     });
-    const frontRim = new THREE.Mesh(new THREE.TorusGeometry(1.47, 0.035, 16, 128), rimMaterial);
-    frontRim.position.z = 0.18;
+    const frontRim = new THREE.Mesh(new THREE.TorusGeometry(1.47, 0.028, 12, 128), rimMaterial);
+    frontRim.position.z = 0.13;
     group.add(frontRim);
 
     const backRim = frontRim.clone();
-    backRim.position.z = -0.18;
+    backRim.position.z = -0.13;
     group.add(backRim);
+
+    const ridges = new THREE.Group();
+    const ridgeMaterial = new THREE.MeshStandardMaterial({
+      color: 0x8f5b16,
+      metalness: 0.9,
+      roughness: 0.28
+    });
+    for (let index = 0; index < 64; index += 1) {
+      const angle = (index / 64) * Math.PI * 2;
+      const ridge = new THREE.Mesh(new THREE.BoxGeometry(0.026, 0.21, 0.012), ridgeMaterial);
+      ridge.position.set(Math.cos(angle) * 1.458, 0, Math.sin(angle) * 1.458);
+      ridge.rotation.y = angle;
+      ridges.add(ridge);
+    }
+    ridges.rotation.x = Math.PI / 2;
+    group.add(ridges);
 
     return group;
   }
@@ -432,6 +445,23 @@
     context.ellipse(0, 0, radius * 0.79, radius * 0.79, 0, 0, Math.PI * 2);
     context.stroke();
 
+    context.save();
+    context.globalAlpha = 0.72;
+    context.lineWidth = Math.max(1, size * 0.004);
+    for (let ridge = 0; ridge < 64; ridge += 1) {
+      const angle = (ridge / 64) * Math.PI * 2;
+      const innerX = Math.cos(angle) * radius * 1.01;
+      const innerY = Math.sin(angle) * radius * 1.01;
+      const outerX = Math.cos(angle) * radius * 1.045;
+      const outerY = Math.sin(angle) * radius * 1.045;
+      context.beginPath();
+      context.moveTo(innerX, innerY);
+      context.lineTo(outerX, outerY);
+      context.strokeStyle = ridge % 2 ? '#ffe9a3' : '#8f5b16';
+      context.stroke();
+    }
+    context.restore();
+
     context.textAlign = 'center';
     context.textBaseline = 'middle';
     context.shadowColor = 'rgba(111, 63, 11, 0.52)';
@@ -439,9 +469,6 @@
     context.fillStyle = '#6f3f0b';
     context.font = `900 ${Math.floor(size * 0.13)}px Poppins, Inter, Arial, sans-serif`;
     context.fillText('3dvr', 0, -size * 0.018);
-    context.fillStyle = '#8a5515';
-    context.font = `800 ${Math.floor(size * 0.075)}px Poppins, Inter, Arial, sans-serif`;
-    context.fillText('.tech', 0, size * 0.1);
     context.restore();
   }
 

--- a/homepage-logo-token.js
+++ b/homepage-logo-token.js
@@ -39,6 +39,7 @@
     idleSpin: 0,
     spinVelocityX: 0,
     spinVelocityY: 0,
+    portalPhase: 0,
     lastTimestamp: 0,
     lastDragTimestamp: 0,
     renderer: null,
@@ -111,6 +112,28 @@
       context.stroke();
     }
     context.globalAlpha = 1;
+    context.restore();
+
+    context.save();
+    context.translate(size / 2, size / 2);
+    const portalGradient = context.createRadialGradient(0, 0, size * 0.035, 0, 0, size * 0.34);
+    portalGradient.addColorStop(0, '#020814');
+    portalGradient.addColorStop(0.38, '#0a2742');
+    portalGradient.addColorStop(0.78, '#135a74');
+    portalGradient.addColorStop(1, 'rgba(19, 90, 116, 0)');
+    context.globalAlpha = 0.92;
+    context.fillStyle = portalGradient;
+    context.beginPath();
+    context.arc(0, 0, size * 0.35, 0, Math.PI * 2);
+    context.fill();
+    context.globalAlpha = 0.72;
+    context.strokeStyle = '#69f5ff';
+    context.lineWidth = 6;
+    for (let portalRing = 1; portalRing <= 3; portalRing += 1) {
+      context.beginPath();
+      context.arc(0, 0, size * (0.1 + portalRing * 0.075), 0, Math.PI * 2);
+      context.stroke();
+    }
     context.restore();
 
     context.beginPath();
@@ -218,6 +241,22 @@
     ridges.rotation.x = Math.PI / 2;
     group.add(ridges);
 
+    const portalRings = new THREE.Group();
+    const portalMaterials = [0x76f7ff, 0x36b8ff, 0x9e7bff].map((color) => new THREE.MeshBasicMaterial({
+      color,
+      transparent: true,
+      opacity: 0.72
+    }));
+    [0.34, 0.54, 0.74].forEach((radius, index) => {
+      const ring = new THREE.Mesh(new THREE.TorusGeometry(radius, 0.012, 10, 96), portalMaterials[index]);
+      ring.position.z = 0.142;
+      ring.userData.phase = index * 1.8;
+      ring.userData.radius = radius;
+      portalRings.add(ring);
+    });
+    group.add(portalRings);
+    group.userData.portalRings = portalRings;
+
     return group;
   }
 
@@ -235,6 +274,7 @@
     }
 
     state.idleSpin += elapsed * (IDLE_QUARTER_SPIN_SPEED + state.spinVelocityY);
+    state.portalPhase = (state.portalPhase + elapsed * 0.0024) % (Math.PI * 2);
 
     if (state.spinVelocityY !== 0) {
       state.spinVelocityY *= Math.pow(SPIN_MOMENTUM_DECAY, elapsed / 16.67);
@@ -287,6 +327,15 @@
     if (state.token && state.renderer && state.scene && state.camera) {
       const rotation = getRenderRotation();
       state.token.rotation.set(rotation.x, rotation.y, rotation.z);
+      const portalRings = state.token.userData.portalRings;
+      if (portalRings) {
+        portalRings.rotation.z = state.portalPhase * 0.42;
+        portalRings.children.forEach((ring) => {
+          const pulse = 1 + Math.sin(state.portalPhase * 2 + ring.userData.phase) * 0.035;
+          ring.scale.setScalar(pulse);
+          ring.rotation.z = state.portalPhase * (ring.userData.radius < 0.5 ? -0.7 : 0.5);
+        });
+      }
       state.renderer.render(state.scene, state.camera);
       return;
     }
@@ -458,6 +507,29 @@
       context.moveTo(innerX, innerY);
       context.lineTo(outerX, outerY);
       context.strokeStyle = ridge % 2 ? '#ffe9a3' : '#8f5b16';
+      context.stroke();
+    }
+    context.restore();
+
+    context.save();
+    context.globalAlpha = 0.82;
+    const portalRadius = radius * 0.72;
+    const portalGradient = context.createRadialGradient(0, 0, portalRadius * 0.06, 0, 0, portalRadius);
+    portalGradient.addColorStop(0, '#020814');
+    portalGradient.addColorStop(0.46, '#0a2742');
+    portalGradient.addColorStop(0.82, '#135a74');
+    portalGradient.addColorStop(1, 'rgba(19, 90, 116, 0)');
+    context.fillStyle = portalGradient;
+    context.beginPath();
+    context.arc(0, 0, portalRadius, 0, Math.PI * 2);
+    context.fill();
+    context.globalAlpha = 0.74;
+    context.lineWidth = Math.max(1, size * 0.006);
+    context.strokeStyle = '#69f5ff';
+    for (let portalRing = 1; portalRing <= 3; portalRing += 1) {
+      const ringRadius = portalRadius * (0.28 + portalRing * 0.2 + Math.sin(state.portalPhase * 2 + portalRing) * 0.012);
+      context.beginPath();
+      context.arc(0, 0, ringRadius, state.portalPhase * (portalRing % 2 ? 0.45 : -0.35), Math.PI * 2 + state.portalPhase * (portalRing % 2 ? 0.45 : -0.35));
       context.stroke();
     }
     context.restore();

--- a/homepage-logo-token.js
+++ b/homepage-logo-token.js
@@ -157,8 +157,8 @@
     context.fillStyle = '#6f3f0b';
     context.shadowColor = 'rgba(0, 0, 0, 0.45)';
     context.shadowBlur = 24;
-    context.font = '900 168px Poppins, Inter, Arial, sans-serif';
-    context.fillText('3dvr', 0, -20);
+    context.font = '900 220px Poppins, Inter, Arial, sans-serif';
+    context.fillText('3dvr', 0, 0);
     context.restore();
 
     const texture = new THREE.CanvasTexture(textureCanvas);
@@ -539,8 +539,8 @@
     context.shadowColor = 'rgba(111, 63, 11, 0.52)';
     context.shadowBlur = size * 0.025;
     context.fillStyle = '#6f3f0b';
-    context.font = `900 ${Math.floor(size * 0.13)}px Poppins, Inter, Arial, sans-serif`;
-    context.fillText('3dvr', 0, -size * 0.018);
+    context.font = `900 ${Math.floor(size * 0.18)}px Poppins, Inter, Arial, sans-serif`;
+    context.fillText('3dvr', 0, 0);
     context.restore();
   }
 

--- a/tests/logo-branding.test.js
+++ b/tests/logo-branding.test.js
@@ -67,10 +67,7 @@ describe('3dvr-web logo branding', () => {
     assert.match(token, /font = '900 220px Poppins, Inter, Arial, sans-serif'/);
     assert.match(token, /fillText\('3dvr', 0, 0\)/);
     assert.match(token, /context\.lineTo\(outerX, outerY\)/);
-    assert.match(token, /portalPhase/);
-    assert.match(token, /portalRings/);
-    assert.match(token, /MeshBasicMaterial/);
-    assert.match(token, /69f5ff/);
+    assert.doesNotMatch(token, /portalPhase|portalRings|MeshBasicMaterial|69f5ff|portalGradient/);
     assert.match(token, /CanvasTexture/);
     assert.match(token, /targetX: 0/);
     assert.match(token, /targetY: 0/);

--- a/tests/logo-branding.test.js
+++ b/tests/logo-branding.test.js
@@ -65,6 +65,10 @@ describe('3dvr-web logo branding', () => {
     assert.match(token, /for \(let index = 0; index < 64; index \+= 1\)/);
     assert.doesNotMatch(token, /fillText\('\.tech'/);
     assert.match(token, /context\.lineTo\(outerX, outerY\)/);
+    assert.match(token, /portalPhase/);
+    assert.match(token, /portalRings/);
+    assert.match(token, /MeshBasicMaterial/);
+    assert.match(token, /69f5ff/);
     assert.match(token, /CanvasTexture/);
     assert.match(token, /targetX: 0/);
     assert.match(token, /targetY: 0/);

--- a/tests/logo-branding.test.js
+++ b/tests/logo-branding.test.js
@@ -61,6 +61,10 @@ describe('3dvr-web logo branding', () => {
     assert.match(token, /MANUAL_CURRENT_RETURN = 0\.18/);
     assert.match(token, /CylinderGeometry/);
     assert.match(token, /TorusGeometry/);
+    assert.match(token, /BoxGeometry\(0\.026, 0\.21, 0\.012\)/);
+    assert.match(token, /for \(let index = 0; index < 64; index \+= 1\)/);
+    assert.doesNotMatch(token, /fillText\('\.tech'/);
+    assert.match(token, /context\.lineTo\(outerX, outerY\)/);
     assert.match(token, /CanvasTexture/);
     assert.match(token, /targetX: 0/);
     assert.match(token, /targetY: 0/);

--- a/tests/logo-branding.test.js
+++ b/tests/logo-branding.test.js
@@ -64,6 +64,8 @@ describe('3dvr-web logo branding', () => {
     assert.match(token, /BoxGeometry\(0\.026, 0\.21, 0\.012\)/);
     assert.match(token, /for \(let index = 0; index < 64; index \+= 1\)/);
     assert.doesNotMatch(token, /fillText\('\.tech'/);
+    assert.match(token, /font = '900 220px Poppins, Inter, Arial, sans-serif'/);
+    assert.match(token, /fillText\('3dvr', 0, 0\)/);
     assert.match(token, /context\.lineTo\(outerX, outerY\)/);
     assert.match(token, /portalPhase/);
     assert.match(token, /portalRings/);


### PR DESCRIPTION
## What changed\n- Keep only Welcome to 3dvr

CRM focus:
Lead: Gloss Hair Studio San Diego CA | status: new | score: 2026-08-08
Category: Web-contact
Site: https://glosshairstudio4s.com/
Contact: https://glosshairstudio4s.com/

What needs attention?

1) Continue outreach          Show the next lead and opener
2) Show lead card             Open the current lead summary
3) Mark contacted             Save the current lead as contacted
4) Check inbox                Look for replies that need attention
5) See agent status           Leads, inbox worker, outreach worker, heartbeat
6) Start/stop background      Manage the local worker
7) Connect email              Gmail now, Outlook later
8) Open portal                Continue in the browser
9) Settings                   Show local config
0) Mark sent + next           Mark the last shown lead, then load the next one
10) Auto-send current         Send the current lead: Gloss Hair Studio San Diego CA, or the next queue item if none is loaded

Numbers keep you in the cockpit. Commands also work here: `next`, `contacted`, `sent-next`, `send-auto`, `ask-form`, `inbox check`, `status`, `crm`, or direct `ask-*` commands.
If you already drafted the last lead on mobile, press 0.
If you want the cockpit to send the loaded lead for you, press 10.

Choose:  on the coin face\n- Thin the coin body and face rims\n- Add quarter-style ridges around the perimeter in WebGL and canvas fallback\n\n## Verification\n- npm run test:unit (37/37)\n- node --check homepage-logo-token.js\n- git diff --check\n\nPR #257 is already merged; this is the visual refinement follow-up.